### PR TITLE
Fix invalid parameter handling in OBS SetScene command

### DIFF
--- a/Commands/ObsCommand.cs
+++ b/Commands/ObsCommand.cs
@@ -129,6 +129,7 @@ public class ObsSetSceneCommand(IObsController obs) : IExecutableCommand
         if (parameters.Length != 1)
         {
             Console.WriteLine("Invalid Parametercount");
+            return;
         }
 
         var sceneName = parameters[0];


### PR DESCRIPTION
## Summary
- handle invalid parameter count in `ObsSetSceneCommand`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686428cbff2c832392dbbfa4829f57ee