### PR TITLE
Fix saturation payload in ElgatoController

### DIFF
--- a/Services/ElgatoController.cs
+++ b/Services/ElgatoController.cs
@@ -154,7 +154,7 @@ public class ElgatoController : IDisposable, IElgatoController
             return;
         }
 
-        var jsonData = $"{{\"lights\":[{{\"hue\":{saturation}}}]}}";
+        var jsonData = $"{{\"lights\":[{{\"saturation\":{saturation}}}]}}";
 
         await SendPutRequestAsync(keyLight.Url, jsonData);
 


### PR DESCRIPTION
## Summary
- fix JSON key in `SetSaturation`
- confirm other setters use correct keys

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642ac7cbf48323b559f7d14248cd92