### PR TITLE
Fix OBS connection deadlock

### DIFF
--- a/Services/ObsController.cs
+++ b/Services/ObsController.cs
@@ -151,7 +151,9 @@ public class ObsController : IObsController
     {
         if (!_obs.IsConnected)
         {
-            await ConnectAndWaitAsync();
+            // Avoid capturing the current SynchronizationContext to prevent
+            // deadlocks when called from a synchronously blocked context.
+            await ConnectAndWaitAsync().ConfigureAwait(false);
         }
 
         return _obs.IsConnected;
@@ -180,7 +182,7 @@ public class ObsController : IObsController
 
     public async Task ToggleVirtualCamera()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -197,7 +199,7 @@ public class ObsController : IObsController
 
     public async Task StartStreaming()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -214,7 +216,7 @@ public class ObsController : IObsController
 
     public async Task StopStreaming()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -235,7 +237,7 @@ public class ObsController : IObsController
 
     public async Task StartRecording()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -253,7 +255,7 @@ public class ObsController : IObsController
 
     public async Task StopRecording()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -271,7 +273,7 @@ public class ObsController : IObsController
 
     public async Task PauseRecording()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             Connect();
         }
@@ -289,7 +291,7 @@ public class ObsController : IObsController
 
     public async Task StartReplayBuffer()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -307,7 +309,7 @@ public class ObsController : IObsController
 
     public async Task StopReplayBuffer()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -325,7 +327,7 @@ public class ObsController : IObsController
 
     public async Task SaveReplayBuffer()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -347,7 +349,7 @@ public class ObsController : IObsController
 
     public async Task ToggleMute(string sourceName)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -365,7 +367,7 @@ public class ObsController : IObsController
 
     public async Task SetVolume(string sourceName, float volume)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -383,7 +385,7 @@ public class ObsController : IObsController
 
     public async Task<float> GetInputVolume(string inputName)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return 0f;
         }
@@ -402,7 +404,7 @@ public class ObsController : IObsController
 
     public async Task<bool> IsInputMuted(string inputName)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return false;
         }
@@ -425,7 +427,7 @@ public class ObsController : IObsController
 
     public async Task ShowSource(string sceneName, int sceneItemId)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -443,7 +445,7 @@ public class ObsController : IObsController
 
     public async Task HideSource(string sceneName, int sceneItemId)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -461,7 +463,7 @@ public class ObsController : IObsController
 
     public async Task ToggleSourceVisibility(string sceneName, int sceneItemId)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -486,7 +488,7 @@ public class ObsController : IObsController
 
     public async Task SetScene(string sceneName)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }
@@ -504,7 +506,7 @@ public class ObsController : IObsController
 
     public async Task<string> GetCurrentSceneName()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return string.Empty;
         }
@@ -523,7 +525,7 @@ public class ObsController : IObsController
 
     public async Task<List<SceneBasicInfo>> GetScenes()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return [];
         }
@@ -546,7 +548,7 @@ public class ObsController : IObsController
 
     public async Task<bool> IsStudioModeEnabled()
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return false;
         }
@@ -565,7 +567,7 @@ public class ObsController : IObsController
 
     public async Task SetStudioMode(bool enabled)
     {
-        if (!await CheckConnection())
+        if (!await CheckConnection().ConfigureAwait(false))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- avoid capturing SynchronizationContext when connecting to OBS
- use `ConfigureAwait(false)` for all OBS connection checks