### PR TITLE
feat: layer-based touch button editor with image/text/symbol layers

### DIFF
--- a/Controllers/LoupedeckLiveSController.cs
+++ b/Controllers/LoupedeckLiveSController.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using LoupixDeck.LoupedeckDevice;
 using LoupixDeck.Models;
 using LoupixDeck.Models.Extensions;
+using LoupixDeck.Models.Layers;
 using LoupixDeck.Services;
 using LoupixDeck.Services.FolderNavigation;
 using LoupixDeck.Utils;
@@ -21,6 +22,7 @@ public class LoupedeckLiveSController(
     IPageManager pageManager,
     IConfigService configService,
     IFolderNavigationService folderNav,
+    IAssetService assetService,
     LoupedeckConfig config)
 {
     private readonly string _configPath = FileDialogHelper.GetConfigPath("config.json");
@@ -435,10 +437,8 @@ public class LoupedeckLiveSController(
 
     private readonly SemaphoreSlim _saveSemaphore = new(1, 1);
 
-    // Fire-and-forget: serialization (incl. SKBitmap -> PNG -> base64) is
-    // expensive enough to hitch the UI thread for ~2s on configs with images,
-    // so the actual save runs on the threadpool. The semaphore serializes
-    // concurrent calls to keep the temp-file rename atomic.
+    // Fire-and-forget save. The semaphore serializes concurrent calls so the
+    // temp-file rename stays atomic.
     public void SaveConfig()
     {
         _ = SaveConfigAsync();
@@ -449,7 +449,20 @@ public class LoupedeckLiveSController(
         await _saveSemaphore.WaitAsync().ConfigureAwait(false);
         try
         {
-            await Task.Run(() => configService.SaveConfig(config, _configPath)).ConfigureAwait(false);
+            // Marshal serialization onto the UI thread: the config tree contains
+            // ObservableCollections (pages → buttons → layers) that the UI may
+            // mutate at any time. Iterating them off-thread races and throws
+            // "Collection was modified". With the layer-based config we no
+            // longer embed bitmaps, so the JSON write itself is cheap enough to
+            // run on the UI thread without a perceptible hitch.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => configService.SaveConfig(config, _configPath));
+
+            // Snapshot referenced asset paths on the UI thread, then perform
+            // the actual filesystem cleanup off-thread.
+            var referenced = await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => CollectReferencedAssetPaths().ToList());
+            await Task.Run(() => assetService.Cleanup(referenced)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -458,6 +471,25 @@ public class LoupedeckLiveSController(
         finally
         {
             _saveSemaphore.Release();
+        }
+    }
+
+    private IEnumerable<string> CollectReferencedAssetPaths()
+    {
+        if (config.TouchButtonPages == null) yield break;
+
+        foreach (var page in config.TouchButtonPages)
+        {
+            if (page?.TouchButtons == null) continue;
+            foreach (var button in page.TouchButtons)
+            {
+                if (button?.Layers == null) continue;
+                foreach (var layer in button.Layers)
+                {
+                    if (layer is ImageLayer img && !string.IsNullOrWhiteSpace(img.AssetRelativePath))
+                        yield return img.AssetRelativePath;
+                }
+            }
         }
     }
 

--- a/Models/Layers/ImageLayer.cs
+++ b/Models/Layers/ImageLayer.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+using SkiaSharp;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// A layer that renders an image from the asset folder. The asset is referenced
+/// by relative path; the actual bitmap is loaded lazily via the asset service
+/// and cached in <see cref="CachedImage"/>.
+/// </summary>
+public class ImageLayer : LayerBase
+{
+    public const string Kind = "image";
+
+    private string _assetRelativePath;
+    private SerializableRect _sourceRect = SerializableRect.Empty;
+    private SKBitmap _cachedImage;
+
+    public string AssetRelativePath
+    {
+        get => _assetRelativePath;
+        set
+        {
+            if (SetField(ref _assetRelativePath, value))
+            {
+                _cachedImage = null;
+                OnPropertyChanged(nameof(CachedImage));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Crop window on the original image. <see cref="SerializableRect.Empty"/>
+    /// means "use the full image".
+    /// </summary>
+    public SerializableRect SourceRect
+    {
+        get => _sourceRect;
+        set => SetField(ref _sourceRect, value);
+    }
+
+    [JsonIgnore]
+    public SKBitmap CachedImage
+    {
+        get => _cachedImage;
+        set
+        {
+            if (ReferenceEquals(_cachedImage, value)) return;
+            _cachedImage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public override string LayerKind => Kind;
+}

--- a/Models/Layers/LayerBase.cs
+++ b/Models/Layers/LayerBase.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// Base class for all touch-button layers (image, text, symbol, …).
+/// Property changes fire <see cref="INotifyPropertyChanged"/> so the owning
+/// <see cref="TouchButton"/> can re-render. Position/Scale are expressed in
+/// 90×90 device-pixel space; the editor canvas applies its own zoom factor.
+/// </summary>
+public abstract class LayerBase : INotifyPropertyChanged
+{
+    private string _name = string.Empty;
+    private bool _visible = true;
+    private int _positionX;
+    private int _positionY;
+    private double _scale = 1.0;
+    private double _scaleY;
+    private double _rotation;
+
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Name
+    {
+        get => _name;
+        set => SetField(ref _name, value);
+    }
+
+    public bool Visible
+    {
+        get => _visible;
+        set => SetField(ref _visible, value);
+    }
+
+    public int PositionX
+    {
+        get => _positionX;
+        set => SetField(ref _positionX, value);
+    }
+
+    public int PositionY
+    {
+        get => _positionY;
+        set => SetField(ref _positionY, value);
+    }
+
+    public double Scale
+    {
+        get => _scale;
+        set => SetField(ref _scale, value);
+    }
+
+    /// <summary>
+    /// Optional Y-axis multiplier. <c>0</c> means "follow <see cref="Scale"/>" so
+    /// existing layers keep uniform behavior; anything &gt; 0 enables anisotropic
+    /// resize (e.g. Shift-drag breaks aspect lock).
+    /// </summary>
+    public double ScaleY
+    {
+        get => _scaleY;
+        set => SetField(ref _scaleY, value);
+    }
+
+    [JsonIgnore]
+    public double EffectiveScaleX => _scale <= 0 ? 1.0 : _scale;
+
+    [JsonIgnore]
+    public double EffectiveScaleY => _scaleY > 0 ? _scaleY : EffectiveScaleX;
+
+    public double Rotation
+    {
+        get => _rotation;
+        set => SetField(ref _rotation, value);
+    }
+
+    [JsonIgnore]
+    public abstract string LayerKind { get; }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+}

--- a/Models/Layers/LayerJsonConverter.cs
+++ b/Models/Layers/LayerJsonConverter.cs
@@ -1,0 +1,76 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// Polymorphic Newtonsoft JSON converter for <see cref="LayerBase"/>. Reads/writes
+/// a "kind" discriminator property so the JSON stays stable independent of the
+/// CLR type name (no TypeNameHandling required).
+/// </summary>
+public class LayerJsonConverter : JsonConverter<LayerBase>
+{
+    private const string KindProperty = "kind";
+
+    public override bool CanWrite => true;
+    public override bool CanRead => true;
+
+    public override void WriteJson(JsonWriter writer, LayerBase value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        var token = JObject.FromObject(value, JsonSerializer.Create(StripSelf(serializer)));
+        token.AddFirst(new JProperty(KindProperty, value.LayerKind));
+        token.WriteTo(writer);
+    }
+
+    public override LayerBase ReadJson(JsonReader reader, Type objectType, LayerBase existingValue,
+        bool hasExistingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null) return null;
+
+        var obj = JObject.Load(reader);
+        var kind = obj[KindProperty]?.Value<string>();
+
+        LayerBase target = kind switch
+        {
+            ImageLayer.Kind => new ImageLayer(),
+            TextLayer.Kind => new TextLayer(),
+            SymbolLayer.Kind => new SymbolLayer(),
+            _ => throw new JsonSerializationException($"Unknown layer kind '{kind}'.")
+        };
+
+        using var sub = obj.CreateReader();
+        JsonSerializer.Create(StripSelf(serializer)).Populate(sub, target);
+        return target;
+    }
+
+    /// <summary>
+    /// Returns serializer settings without this converter so that
+    /// JObject.FromObject / Populate use the default object serializer for the
+    /// concrete type instead of recursing into this converter.
+    /// </summary>
+    private static JsonSerializerSettings StripSelf(JsonSerializer source)
+    {
+        var settings = new JsonSerializerSettings
+        {
+            Formatting = source.Formatting,
+            NullValueHandling = source.NullValueHandling,
+            DefaultValueHandling = source.DefaultValueHandling,
+            ContractResolver = source.ContractResolver,
+            ReferenceLoopHandling = source.ReferenceLoopHandling
+        };
+
+        foreach (var converter in source.Converters)
+        {
+            if (converter is LayerJsonConverter) continue;
+            settings.Converters.Add(converter);
+        }
+
+        return settings;
+    }
+}

--- a/Models/Layers/SerializableRect.cs
+++ b/Models/Layers/SerializableRect.cs
@@ -1,0 +1,40 @@
+using SkiaSharp;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// JSON-friendly rectangle (SKRect contains private state that Newtonsoft cannot
+/// always round-trip cleanly). Empty/zero-size means "no crop, use full source".
+/// </summary>
+public struct SerializableRect : IEquatable<SerializableRect>
+{
+    public float Left { get; set; }
+    public float Top { get; set; }
+    public float Right { get; set; }
+    public float Bottom { get; set; }
+
+    public SerializableRect(float left, float top, float right, float bottom)
+    {
+        Left = left;
+        Top = top;
+        Right = right;
+        Bottom = bottom;
+    }
+
+    public static SerializableRect Empty => new(0, 0, 0, 0);
+
+    public bool IsEmpty => Left == 0 && Top == 0 && Right == 0 && Bottom == 0;
+
+    public float Width => Right - Left;
+    public float Height => Bottom - Top;
+
+    public SKRect ToSKRect() => new(Left, Top, Right, Bottom);
+
+    public static SerializableRect FromSKRect(SKRect r) => new(r.Left, r.Top, r.Right, r.Bottom);
+
+    public bool Equals(SerializableRect other) =>
+        Left == other.Left && Top == other.Top && Right == other.Right && Bottom == other.Bottom;
+
+    public override bool Equals(object obj) => obj is SerializableRect r && Equals(r);
+    public override int GetHashCode() => HashCode.Combine(Left, Top, Right, Bottom);
+}

--- a/Models/Layers/SymbolLayer.cs
+++ b/Models/Layers/SymbolLayer.cs
@@ -1,0 +1,29 @@
+using Avalonia.Media;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// Placeholder for the upcoming symbol-library feature. Until the picker exists
+/// the renderer draws a labeled placeholder box.
+/// </summary>
+public class SymbolLayer : LayerBase
+{
+    public const string Kind = "symbol";
+
+    private string _symbolId = string.Empty;
+    private Color _tint = Colors.White;
+
+    public string SymbolId
+    {
+        get => _symbolId;
+        set => SetField(ref _symbolId, value);
+    }
+
+    public Color Tint
+    {
+        get => _tint;
+        set => SetField(ref _tint, value);
+    }
+
+    public override string LayerKind => Kind;
+}

--- a/Models/Layers/TextLayer.cs
+++ b/Models/Layers/TextLayer.cs
@@ -1,0 +1,99 @@
+using Avalonia.Media;
+using Newtonsoft.Json;
+
+namespace LoupixDeck.Models.Layers;
+
+/// <summary>
+/// A layer that renders text. Inherits position/scale from <see cref="LayerBase"/>;
+/// when <see cref="Centered"/> is true, position is interpreted as an offset from
+/// the button center, otherwise as the upper-left corner.
+/// </summary>
+public class TextLayer : LayerBase
+{
+    public const string Kind = "text";
+
+    private string _text = string.Empty;
+    private int _textSize = 16;
+    private Color _textColor = Colors.White;
+    private bool _bold;
+    private bool _italic;
+    private bool _outlined;
+    private Color _outlineColor = Colors.Black;
+    private bool _centered = true;
+    private int _boxWidth;
+    private int _boxHeight;
+
+    /// <summary>
+    /// Width of the text-layout box in device pixels. The renderer wraps text
+    /// at this width and (when <see cref="Centered"/> is true) centers within it.
+    /// <c>0</c> means "fall back to the device size" — covers configs persisted
+    /// before this property existed.
+    /// </summary>
+    public int BoxWidth
+    {
+        get => _boxWidth;
+        set => SetField(ref _boxWidth, value);
+    }
+
+    public int BoxHeight
+    {
+        get => _boxHeight;
+        set => SetField(ref _boxHeight, value);
+    }
+
+    [JsonIgnore]
+    public int EffectiveBoxWidth => _boxWidth > 0 ? _boxWidth : 90;
+
+    [JsonIgnore]
+    public int EffectiveBoxHeight => _boxHeight > 0 ? _boxHeight : 90;
+
+    public string Text
+    {
+        get => _text;
+        set => SetField(ref _text, value);
+    }
+
+    public int TextSize
+    {
+        get => _textSize;
+        set => SetField(ref _textSize, value);
+    }
+
+    public Color TextColor
+    {
+        get => _textColor;
+        set => SetField(ref _textColor, value);
+    }
+
+    public bool Bold
+    {
+        get => _bold;
+        set => SetField(ref _bold, value);
+    }
+
+    public bool Italic
+    {
+        get => _italic;
+        set => SetField(ref _italic, value);
+    }
+
+    public bool Outlined
+    {
+        get => _outlined;
+        set => SetField(ref _outlined, value);
+    }
+
+    public Color OutlineColor
+    {
+        get => _outlineColor;
+        set => SetField(ref _outlineColor, value);
+    }
+
+    public bool Centered
+    {
+        get => _centered;
+        set => SetField(ref _centered, value);
+    }
+
+    public override string LayerKind => Kind;
+}

--- a/Models/LoupedeckConfig.cs
+++ b/Models/LoupedeckConfig.cs
@@ -17,6 +17,16 @@ public class LoupedeckConfig : INotifyPropertyChanged
 
     private int _brightness = 100;
 
+    /// <summary>
+    /// Schema version of the persisted config. Bumped when a breaking change is
+    /// introduced; <see cref="ConfigService"/> discards configs with a different
+    /// version (no migration in v2 — the old single-image touch-button schema is
+    /// not convertible to the new layer schema).
+    /// </summary>
+    public const int CurrentVersion = 2;
+
+    public int Version { get; set; } = CurrentVersion;
+
     public string DevicePort { get; set; }
     public int DeviceBaudrate { get; set; }
 

--- a/Models/TouchButton.cs
+++ b/Models/TouchButton.cs
@@ -1,120 +1,28 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
 using Avalonia.Media;
+using LoupixDeck.Models.Layers;
 using Newtonsoft.Json;
 using SkiaSharp;
 
 namespace LoupixDeck.Models;
 
-public class TouchButton(int index) : LoupedeckButton
+public class TouchButton : LoupedeckButton
 {
-    public int Index { get; } = index;
-
-    private string _text = string.Empty;
-
-    public string Text
+    public TouchButton(int index)
     {
-        get => _text;
-        set
-        {
-            if (value == _text) return;
-            _text = value;
-            //OnPropertyChanged(nameof(Text));
-            Refresh();
-        }
+        Index = index;
+        Layers = new System.Collections.ObjectModel.ObservableCollection<LayerBase>();
+        AttachLayerHandlers(Layers);
     }
 
-    private bool _textCentered = true;
-
-    public bool TextCentered
+    /// <summary>Parameterless ctor for the JSON deserializer.</summary>
+    [JsonConstructor]
+    private TouchButton() : this(0)
     {
-        get => _textCentered;
-        set
-        {
-            if (value == _textCentered) return;
-            _textCentered = value;
-            Refresh();
-            OnPropertyChanged(nameof(TextCentered));
-        }
     }
 
-    private int _textSize = 16;
-
-    public int TextSize
-    {
-        get => _textSize;
-        set
-        {
-            if (value == _textSize) return;
-            _textSize = value;
-            Refresh();
-        }
-    }
-
-    private int _textPositionX;
-
-    public int TextPositionX
-    {
-        get => _textPositionX;
-        set
-        {
-            if (_textPositionX == value) return;
-            _textPositionX = value;
-            Refresh();
-            OnPropertyChanged(nameof(TextPositionX));
-        }
-    }
-
-    private int _textPositionY;
-
-    public int TextPositionY
-    {
-        get => _textPositionY;
-        set
-        {
-            if (_textPositionY == value) return;
-            _textPositionY = value;
-            Refresh();
-            OnPropertyChanged(nameof(TextPositionY));
-        }
-    }
-
-    private Color _textColor = Colors.White;
-
-    public Color TextColor
-    {
-        get => _textColor;
-        set
-        {
-            if (Equals(value, _textColor)) return;
-            _textColor = value;
-            Refresh();
-        }
-    }
-
-    private bool _bold;
-
-    public bool Bold
-    {
-        get => _bold;
-        set
-        {
-            if (value == _bold) return;
-            _bold = value;
-            Refresh();
-        }
-    }
-
-    private bool _italic;
-
-    public bool Italic
-    {
-        get => _italic;
-        set
-        {
-            if (value == _italic) return;
-            _italic = value;
-            Refresh();
-        }
-    }
+    public int Index { get; set; }
 
     private Color _backColor = Colors.Black;
 
@@ -129,85 +37,19 @@ public class TouchButton(int index) : LoupedeckButton
         }
     }
 
-    private bool _outlined;
+    private System.Collections.ObjectModel.ObservableCollection<LayerBase> _layers;
 
-    public bool Outlined
+    public System.Collections.ObjectModel.ObservableCollection<LayerBase> Layers
     {
-        get => _outlined;
+        get => _layers;
         set
         {
-            if (value == _outlined) return;
-            _outlined = value;
+            if (ReferenceEquals(_layers, value)) return;
+            DetachLayerHandlers(_layers);
+            _layers = value ?? new System.Collections.ObjectModel.ObservableCollection<LayerBase>();
+            AttachLayerHandlers(_layers);
             Refresh();
-            OnPropertyChanged(nameof(Outlined));
-        }
-    }
-
-    private Color _outlineColor = Colors.Black;
-
-    public Color OutlineColor
-    {
-        get => _outlineColor;
-        set
-        {
-            if (Equals(value, _outlineColor)) return;
-            _outlineColor = value;
-            Refresh();
-        }
-    }
-
-    private SKBitmap _image;
-
-    public SKBitmap Image
-    {
-        get => _image;
-        set
-        {
-            if (Equals(value, _image)) return;
-            _image = value;
-            Refresh();
-        }
-    }
-
-    private int _imagePositionX;
-
-    public int ImagePositionX
-    {
-        get => _imagePositionX;
-        set
-        {
-            if (_imagePositionX == value) return;
-            _imagePositionX = value;
-            Refresh();
-            OnPropertyChanged(nameof(ImagePositionX));
-        }
-    }
-
-    private int _imagePositionY;
-
-    public int ImagePositionY
-    {
-        get => _imagePositionY;
-        set
-        {
-            if (_imagePositionY == value) return;
-            _imagePositionY = value;
-            Refresh();
-            OnPropertyChanged(nameof(ImagePositionY));
-        }
-    }
-
-    private int _imageScale = 100;
-
-    public int ImageScale
-    {
-        get => _imageScale;
-        set
-        {
-            if (_imageScale == value) return;
-            _imageScale = value;
-            Refresh();
-            OnPropertyChanged(nameof(ImageScale));
+            OnPropertyChanged(nameof(Layers));
         }
     }
 
@@ -222,6 +64,82 @@ public class TouchButton(int index) : LoupedeckButton
             if (Equals(value, _renderedImage)) return;
             _renderedImage = value;
             OnPropertyChanged(nameof(RenderedImage));
+        }
+    }
+
+    private void AttachLayerHandlers(System.Collections.ObjectModel.ObservableCollection<LayerBase> layers)
+    {
+        if (layers == null) return;
+        layers.CollectionChanged += Layers_CollectionChanged;
+        foreach (var layer in layers)
+        {
+            if (layer != null) layer.PropertyChanged += Layer_PropertyChanged;
+        }
+    }
+
+    private void DetachLayerHandlers(System.Collections.ObjectModel.ObservableCollection<LayerBase> layers)
+    {
+        if (layers == null) return;
+        layers.CollectionChanged -= Layers_CollectionChanged;
+        foreach (var layer in layers)
+        {
+            if (layer != null) layer.PropertyChanged -= Layer_PropertyChanged;
+        }
+    }
+
+    private void Layers_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems != null)
+        {
+            foreach (LayerBase l in e.OldItems)
+                if (l != null) l.PropertyChanged -= Layer_PropertyChanged;
+        }
+
+        if (e.NewItems != null)
+        {
+            foreach (LayerBase l in e.NewItems)
+                if (l != null) l.PropertyChanged += Layer_PropertyChanged;
+        }
+
+        Refresh();
+    }
+
+    private void Layer_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        Refresh();
+    }
+
+    /// <summary>
+    /// Returns the first <see cref="TextLayer"/> on this button, creating one
+    /// (and appending it as the top-most layer) if none exists. Intended for
+    /// dynamic-text providers that need a stable text target.
+    /// </summary>
+    public TextLayer GetOrCreatePrimaryTextLayer()
+    {
+        foreach (var layer in Layers)
+        {
+            if (layer is TextLayer text) return text;
+        }
+
+        var created = new TextLayer { Name = "Text", BoxWidth = 90, BoxHeight = 90 };
+        Layers.Add(created);
+        return created;
+    }
+
+    /// <summary>
+    /// Re-attaches PropertyChanged handlers to all layers — call after JSON
+    /// deserialization since the ObservableCollection setter wires up the
+    /// collection events but the individual layers were constructed by the
+    /// JSON converter, bypassing AttachLayerHandlers.
+    /// </summary>
+    public void RewireLayerHandlers()
+    {
+        if (_layers == null) return;
+        foreach (var layer in _layers)
+        {
+            if (layer == null) continue;
+            layer.PropertyChanged -= Layer_PropertyChanged;
+            layer.PropertyChanged += Layer_PropertyChanged;
         }
     }
 }

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         });
 
         collection.AddSingleton<IConfigService, ConfigService>();
+        collection.AddSingleton<IAssetService, AssetService>();
         collection.AddSingleton<ICommandService, CommandService>();
         collection.AddSingleton<IDeviceService, LoupedeckDeviceService>();
         collection.AddSingleton<IPageManager, PageManager>();
@@ -106,5 +107,26 @@ public static class ServiceCollectionExtensions
         dialogService.Register<TouchButtonSettingsViewModel, TouchButtonSettings>();
         dialogService.Register<SettingsViewModel, Settings>();
         dialogService.Register<AboutViewModel, About>();
+
+        // Let the (static) bitmap renderer resolve image-layer assets via DI.
+        var assetService = services.GetRequiredService<IAssetService>();
+        BitmapHelper.AssetResolver = assetService.Load;
+
+        // After config load, rewire per-layer PropertyChanged handlers so edits
+        // trigger TouchButton.Refresh(). The collection setter in TouchButton
+        // wires its own CollectionChanged hook, but layers created by the JSON
+        // converter bypass AttachLayerHandlers.
+        var config = services.GetRequiredService<LoupedeckConfig>();
+        if (config.TouchButtonPages != null)
+        {
+            foreach (var page in config.TouchButtonPages)
+            {
+                if (page?.TouchButtons == null) continue;
+                foreach (var button in page.TouchButtons)
+                {
+                    button?.RewireLayerHandlers();
+                }
+            }
+        }
     }
 }

--- a/Services/AssetService.cs
+++ b/Services/AssetService.cs
@@ -1,0 +1,123 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using LoupixDeck.Utils;
+using SkiaSharp;
+
+namespace LoupixDeck.Services;
+
+public class AssetService : IAssetService
+{
+    private const string AssetsFolderName = "assets";
+
+    private readonly ConcurrentDictionary<string, SKBitmap> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public string AssetsRoot { get; }
+
+    public AssetService()
+    {
+        // GetConfigPath("") returns the config directory (it creates it if missing).
+        var configDir = Path.GetDirectoryName(FileDialogHelper.GetConfigPath("config.json"))
+                        ?? Environment.CurrentDirectory;
+
+        AssetsRoot = Path.Combine(configDir, AssetsFolderName);
+        Directory.CreateDirectory(AssetsRoot);
+    }
+
+    public string Import(string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+            return null;
+
+        string hash;
+        using (var stream = File.OpenRead(sourcePath))
+        using (var sha = SHA256.Create())
+        {
+            hash = Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
+        }
+
+        var ext = Path.GetExtension(sourcePath);
+        if (string.IsNullOrEmpty(ext)) ext = ".png";
+        ext = ext.ToLowerInvariant();
+
+        var targetFileName = hash + ext;
+        var targetAbsolute = Path.Combine(AssetsRoot, targetFileName);
+
+        if (!File.Exists(targetAbsolute))
+        {
+            File.Copy(sourcePath, targetAbsolute, overwrite: false);
+        }
+
+        // Relative path is stored in the config so the folder remains portable.
+        return Path.Combine(AssetsFolderName, targetFileName).Replace('\\', '/');
+    }
+
+    public SKBitmap Load(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath)) return null;
+
+        if (_cache.TryGetValue(relativePath, out var cached) && cached != null)
+            return cached;
+
+        var absolute = ResolveAbsolute(relativePath);
+        if (!File.Exists(absolute)) return null;
+
+        try
+        {
+            var bitmap = SKBitmap.Decode(absolute);
+            if (bitmap != null)
+                _cache[relativePath] = bitmap;
+            return bitmap;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"AssetService: failed to load '{absolute}': {ex.Message}");
+            return null;
+        }
+    }
+
+    public void Cleanup(IEnumerable<string> referencedRelativePaths)
+    {
+        if (!Directory.Exists(AssetsRoot)) return;
+
+        var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rel in referencedRelativePaths ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(rel)) continue;
+            referenced.Add(Path.GetFileName(rel));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(AssetsRoot))
+        {
+            var name = Path.GetFileName(file);
+            if (referenced.Contains(name)) continue;
+
+            try
+            {
+                File.Delete(file);
+                // Drop any cached bitmaps that pointed at this asset.
+                foreach (var key in _cache.Keys)
+                {
+                    if (string.Equals(Path.GetFileName(key), name, StringComparison.OrdinalIgnoreCase))
+                        _cache.TryRemove(key, out _);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"AssetService: failed to delete orphan '{file}': {ex.Message}");
+            }
+        }
+    }
+
+    private string ResolveAbsolute(string relativePath)
+    {
+        var normalized = relativePath.Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(normalized)) return normalized;
+
+        // Strip leading "assets/" if present — AssetsRoot already points there.
+        var prefix = AssetsFolderName + Path.DirectorySeparatorChar;
+        if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            normalized = normalized[prefix.Length..];
+
+        return Path.Combine(AssetsRoot, normalized);
+    }
+}

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -1,5 +1,8 @@
 using Newtonsoft.Json;
+using LoupixDeck.Models;
 using LoupixDeck.Models.Converter;
+using LoupixDeck.Models.Layers;
+using Newtonsoft.Json.Linq;
 
 namespace LoupixDeck.Services;
 
@@ -21,6 +24,7 @@ public class ConfigService : IConfigService
         };
         _settings.Converters.Add(new ColorJsonConverter());
         _settings.Converters.Add(new SKBitmapBase64Converter());
+        _settings.Converters.Add(new LayerJsonConverter());
     }
 
     public T LoadConfig<T>(string filePath) where T : class
@@ -31,6 +35,14 @@ public class ConfigService : IConfigService
                 return null;
 
             var json = File.ReadAllText(filePath);
+
+            if (typeof(T) == typeof(LoupedeckConfig) && !IsCompatibleVersion(json))
+            {
+                Console.WriteLine($"Config version mismatch in {filePath} — backing up and starting fresh.");
+                BackupCorruptedFile(filePath);
+                return null;
+            }
+
             return JsonConvert.DeserializeObject<T>(json, _settings);
         }
         catch (IOException ex)
@@ -67,6 +79,21 @@ public class ConfigService : IConfigService
 
             // Return null to allow application to create new default config
             return null;
+        }
+    }
+
+    private static bool IsCompatibleVersion(string json)
+    {
+        try
+        {
+            var token = JToken.Parse(json);
+            var version = token["Version"]?.Value<int?>() ?? token["version"]?.Value<int?>() ?? 1;
+            return version == LoupedeckConfig.CurrentVersion;
+        }
+        catch
+        {
+            // Let the normal deserialize path surface the parse error.
+            return true;
         }
     }
 

--- a/Services/DynamicTextManager.cs
+++ b/Services/DynamicTextManager.cs
@@ -193,7 +193,7 @@ public class DynamicTextManager : IDynamicTextManager, IDisposable
             }
 
             var button = entry.Button;
-            Dispatcher.UIThread.Post(() => button.Text = newText);
+            Dispatcher.UIThread.Post(() => button.GetOrCreatePrimaryTextLayer().Text = newText);
 
             // Advance NextDue by exactly one interval to stay aligned to the wall clock.
             // If we fell behind by more than one interval, snap forward.

--- a/Services/IAssetService.cs
+++ b/Services/IAssetService.cs
@@ -1,0 +1,33 @@
+using SkiaSharp;
+
+namespace LoupixDeck.Services;
+
+/// <summary>
+/// Stores image assets referenced by touch-button layers next to the config file
+/// (in a sibling "assets/" folder). Assets are content-addressed by SHA-256 so
+/// identical imports are deduplicated.
+/// </summary>
+public interface IAssetService
+{
+    /// <summary>Absolute path to the assets root folder.</summary>
+    string AssetsRoot { get; }
+
+    /// <summary>
+    /// Copies <paramref name="sourcePath"/> into the asset folder under a hashed
+    /// filename and returns the relative path to use in a layer.
+    /// </summary>
+    string Import(string sourcePath);
+
+    /// <summary>
+    /// Loads (and caches) the bitmap for the given relative asset path.
+    /// Returns null if the file is missing or unreadable.
+    /// </summary>
+    SKBitmap Load(string relativePath);
+
+    /// <summary>
+    /// Removes asset files in the asset folder that are not in the provided
+    /// referenced set. Intended to be called during save to keep the folder
+    /// from growing unbounded.
+    /// </summary>
+    void Cleanup(IEnumerable<string> referencedRelativePaths);
+}

--- a/Utils/BitmapHelper.cs
+++ b/Utils/BitmapHelper.cs
@@ -4,12 +4,20 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Media.Immutable;
 using LoupixDeck.Models;
+using LoupixDeck.Models.Layers;
 using SkiaSharp;
 
 namespace LoupixDeck.Utils;
 
 public static class BitmapHelper
 {
+    /// <summary>
+    /// Resolver used by the renderer to fetch an <see cref="SKBitmap"/> for a
+    /// given relative asset path. Wired up at app startup so the static helper
+    /// does not need to know about DI. Returns null if unresolved.
+    /// </summary>
+    public static Func<string, SKBitmap> AssetResolver { get; set; }
+
     public enum ScalingOption
     {
         None, // Image shown as is in full resolution
@@ -177,45 +185,337 @@ public static class BitmapHelper
             canvas.Clear(touchButton.BackColor.ToSKColor());
         }
 
-        if (touchButton.Image != null)
-        {
-            var destRect = new SKRect(0, 0, width, height);
-            
-            var scaledImage = BitmapHelper.ScaleAndPositionBitmap(
-                touchButton.Image,
-                width,
-                height,
-                touchButton.ImageScale,
-                touchButton.ImagePositionX,
-                touchButton.ImagePositionY);
-            
-            canvas.DrawBitmap(scaledImage, destRect);
-        }
-
-        if (!string.IsNullOrEmpty(touchButton.Text))
-        {
-            DrawTextAt(
-                canvas,
-                touchButton.Text,
-                touchButton.TextColor.ToSKColor(),
-                touchButton.TextSize,
-                touchButton.TextCentered,
-                touchButton.TextPositionX,
-                touchButton.TextPositionY,
-                width,
-                height,
-                touchButton.Bold,
-                touchButton.Italic,
-                touchButton.Outlined,
-                touchButton.OutlineColor.ToSKColor()
-            );
-        }
+        DrawLayers(canvas, touchButton.Layers, width, height);
 
         // Convert back to RenderTargetBitmap and save in the TouchButton
         // var rtb = bitmap.ToRenderTargetBitmap();
         touchButton.RenderedImage = bitmap;
 
         return bitmap;
+    }
+
+    /// <summary>
+    /// Renders the touch-button settings dialog preview: a <paramref name="canvasSize"/>
+    /// square with a centered <paramref name="frameSize"/>-pixel frame representing the
+    /// real 90×90 device area. Layers may extend beyond the frame so the user can drag
+    /// images past the button edge — frame clipping happens only on the device-side
+    /// render produced by <see cref="RenderTouchButtonContent"/>.
+    /// </summary>
+    public static SKBitmap RenderEditorCanvas(
+        TouchButton touchButton,
+        LoupedeckConfig config,
+        int canvasSize = 600,
+        int frameSize = 300)
+    {
+        ArgumentNullException.ThrowIfNull(touchButton);
+
+        const int deviceSize = 90;
+
+        var bmp = new SKBitmap(canvasSize, canvasSize);
+        using var canvas = new SKCanvas(bmp);
+
+        canvas.Clear(new SKColor(0x22, 0x22, 0x22));
+
+        var frameOffset = (canvasSize - frameSize) / 2f;
+        var frameRect = new SKRect(frameOffset, frameOffset,
+            frameOffset + frameSize, frameOffset + frameSize);
+
+        // Fill the frame with the button's background color (the device-pixel area).
+        using (var bgPaint = new SKPaint { Color = touchButton.BackColor.ToSKColor() })
+        {
+            canvas.DrawRect(frameRect, bgPaint);
+        }
+
+        // Switch to device-pixel space inside the frame so layer positions/scale match
+        // exactly what the device render produces.
+        canvas.Save();
+        canvas.Translate(frameOffset, frameOffset);
+        canvas.Scale((float)frameSize / deviceSize);
+
+        if (touchButton.Layers != null)
+        {
+            foreach (var layer in touchButton.Layers)
+            {
+                if (layer == null || !layer.Visible) continue;
+
+                switch (layer)
+                {
+                    case ImageLayer image:
+                        DrawImageLayerExtended(canvas, image, deviceSize, deviceSize);
+                        break;
+                    case TextLayer text:
+                        DrawTextLayer(canvas, text, deviceSize, deviceSize);
+                        break;
+                    case SymbolLayer symbol:
+                        DrawSymbolPlaceholder(canvas, symbol, deviceSize, deviceSize);
+                        break;
+                }
+            }
+        }
+
+        canvas.Restore();
+
+        return bmp;
+    }
+
+    /// <summary>
+    /// Returns the on-canvas (editor-preview) rectangle that a layer currently occupies.
+    /// Used by the View to position the selection overlay. Returns null if the layer has
+    /// no resolvable geometry (e.g. image with missing asset).
+    /// </summary>
+    public static SKRect? GetLayerEditorBounds(
+        LayerBase layer,
+        int canvasSize = 600,
+        int frameSize = 300)
+    {
+        if (layer == null || !layer.Visible) return null;
+
+        const int deviceSize = 90;
+        var deviceRect = GetLayerDeviceRect(layer, deviceSize, deviceSize);
+        if (deviceRect == null) return null;
+
+        var frameOffset = (canvasSize - frameSize) / 2f;
+        var scale = (float)frameSize / deviceSize;
+        var dr = deviceRect.Value;
+        return new SKRect(
+            frameOffset + dr.Left * scale,
+            frameOffset + dr.Top * scale,
+            frameOffset + dr.Right * scale,
+            frameOffset + dr.Bottom * scale);
+    }
+
+    /// <summary>
+    /// Returns the bounding rectangle of a layer in 90×90 device-pixel space.
+    /// Mirrors the geometry math used in <see cref="DrawImageLayerExtended"/> /
+    /// <see cref="DrawSymbolPlaceholder"/> so the selection overlay always matches
+    /// the rendered output.
+    /// </summary>
+    private static SKRect? GetLayerDeviceRect(LayerBase layer, int deviceW, int deviceH)
+    {
+        switch (layer)
+        {
+            case ImageLayer image:
+            {
+                var bmp = image.CachedImage;
+                if (bmp == null && !string.IsNullOrEmpty(image.AssetRelativePath) && AssetResolver != null)
+                {
+                    bmp = AssetResolver(image.AssetRelativePath);
+                    image.CachedImage = bmp;
+                }
+                if (bmp == null) return null;
+
+                float srcW, srcH;
+                if (!image.SourceRect.IsEmpty &&
+                    image.SourceRect.Width > 0 && image.SourceRect.Height > 0)
+                {
+                    srcW = image.SourceRect.Width;
+                    srcH = image.SourceRect.Height;
+                }
+                else
+                {
+                    srcW = bmp.Width;
+                    srcH = bmp.Height;
+                }
+
+                var fit = Math.Min(deviceW / srcW, deviceH / srcH);
+                var scaleX = (float)Math.Max(0.01, image.EffectiveScaleX);
+                var scaleY = (float)Math.Max(0.01, image.EffectiveScaleY);
+                var dstW = srcW * fit * scaleX;
+                var dstH = srcH * fit * scaleY;
+                var drawX = (deviceW - dstW) / 2f + image.PositionX;
+                var drawY = (deviceH - dstH) / 2f + image.PositionY;
+                return new SKRect(drawX, drawY, drawX + dstW, drawY + dstH);
+            }
+            case SymbolLayer symbol:
+            {
+                var size = Math.Min(deviceW, deviceH) * 0.6f * (float)Math.Max(0.1, symbol.Scale);
+                var cx = deviceW / 2f + symbol.PositionX;
+                var cy = deviceH / 2f + symbol.PositionY;
+                return new SKRect(cx - size / 2f, cy - size / 2f, cx + size / 2f, cy + size / 2f);
+            }
+            case TextLayer text:
+                return MeasureTextDeviceRect(text, deviceW, deviceH);
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the bounding rectangle (in device-pixel space) that the given text
+    /// layer occupies when rendered by <see cref="DrawTextAt"/>. Mirrors the same
+    /// font metrics + wrap logic so the editor selection overlay tracks the text.
+    /// </summary>
+    /// <summary>
+    /// Returns the text-layout box rectangle in device-pixel space. This is the
+    /// area the renderer wraps text into; the selection overlay tracks it so the
+    /// user can drag the corners/edges to enlarge or shrink the wrap area.
+    /// </summary>
+    private static SKRect MeasureTextDeviceRect(TextLayer layer, int deviceW, int deviceH)
+    {
+        var (boxLeft, boxTop) = TextBoxOrigin(layer, deviceW, deviceH);
+        return new SKRect(boxLeft, boxTop,
+            boxLeft + layer.EffectiveBoxWidth,
+            boxTop + layer.EffectiveBoxHeight);
+    }
+
+    /// <summary>
+    /// Editor-canvas variant of <see cref="DrawImageLayer"/> that does NOT pre-render to
+    /// a clipped 90×90 surface — it lets the image overflow the device area so the user
+    /// can see what they're dragging past the frame.
+    /// </summary>
+    private static void DrawImageLayerExtended(SKCanvas canvas, ImageLayer layer, int deviceW, int deviceH)
+    {
+        var bmp = layer.CachedImage;
+        if (bmp == null && !string.IsNullOrEmpty(layer.AssetRelativePath) && AssetResolver != null)
+        {
+            bmp = AssetResolver(layer.AssetRelativePath);
+            layer.CachedImage = bmp;
+        }
+        if (bmp == null) return;
+
+        SKRect srcRect;
+        if (!layer.SourceRect.IsEmpty &&
+            layer.SourceRect.Width > 0 && layer.SourceRect.Height > 0)
+        {
+            srcRect = layer.SourceRect.ToSKRect();
+        }
+        else
+        {
+            srcRect = new SKRect(0, 0, bmp.Width, bmp.Height);
+        }
+
+        var fit = Math.Min(deviceW / srcRect.Width, deviceH / srcRect.Height);
+        var scaleX = (float)Math.Max(0.01, layer.EffectiveScaleX);
+        var scaleY = (float)Math.Max(0.01, layer.EffectiveScaleY);
+        var dstW = srcRect.Width * fit * scaleX;
+        var dstH = srcRect.Height * fit * scaleY;
+        var drawX = (deviceW - dstW) / 2f + layer.PositionX;
+        var drawY = (deviceH - dstH) / 2f + layer.PositionY;
+
+        canvas.DrawBitmap(bmp, srcRect, new SKRect(drawX, drawY, drawX + dstW, drawY + dstH));
+    }
+
+    /// <summary>
+    /// Iterates the layer collection in order (later entries paint on top) and
+    /// dispatches to the appropriate per-layer renderer.
+    /// </summary>
+    private static void DrawLayers(SKCanvas canvas,
+        System.Collections.ObjectModel.ObservableCollection<LayerBase> layers,
+        int width, int height)
+    {
+        if (layers == null) return;
+
+        foreach (var layer in layers)
+        {
+            if (layer == null || !layer.Visible) continue;
+
+            switch (layer)
+            {
+                case ImageLayer image:
+                    DrawImageLayer(canvas, image, width, height);
+                    break;
+                case TextLayer text:
+                    DrawTextLayer(canvas, text, width, height);
+                    break;
+                case SymbolLayer symbol:
+                    DrawSymbolPlaceholder(canvas, symbol, width, height);
+                    break;
+            }
+        }
+    }
+
+    private static void DrawImageLayer(SKCanvas canvas, ImageLayer layer, int width, int height)
+    {
+        var bmp = layer.CachedImage;
+        if (bmp == null && !string.IsNullOrEmpty(layer.AssetRelativePath) && AssetResolver != null)
+        {
+            bmp = AssetResolver(layer.AssetRelativePath);
+            layer.CachedImage = bmp;
+        }
+        if (bmp == null) return;
+
+        // Draw directly onto the target canvas so layer alpha composites correctly.
+        // The previous approach materialised an intermediate SKBitmap with the source's
+        // AlphaType — for opaque sources (e.g. JPEG) the "transparent" surrounding area
+        // stayed fully opaque black and overwrote any layers drawn beneath this one.
+        var srcRect = (!layer.SourceRect.IsEmpty &&
+                       layer.SourceRect.Width > 0 && layer.SourceRect.Height > 0)
+            ? layer.SourceRect.ToSKRect()
+            : new SKRect(0, 0, bmp.Width, bmp.Height);
+
+        var fit = Math.Min(width / srcRect.Width, height / srcRect.Height);
+        var scaleX = (float)Math.Max(0.01, layer.EffectiveScaleX);
+        var scaleY = (float)Math.Max(0.01, layer.EffectiveScaleY);
+        var dstW = srcRect.Width * fit * scaleX;
+        var dstH = srcRect.Height * fit * scaleY;
+        var drawX = (width - dstW) / 2f + layer.PositionX;
+        var drawY = (height - dstH) / 2f + layer.PositionY;
+
+        canvas.Save();
+        canvas.ClipRect(new SKRect(0, 0, width, height));
+        canvas.DrawBitmap(bmp, srcRect, new SKRect(drawX, drawY, drawX + dstW, drawY + dstH));
+        canvas.Restore();
+    }
+
+    private static void DrawTextLayer(SKCanvas canvas, TextLayer layer, int width, int height)
+    {
+        if (string.IsNullOrEmpty(layer.Text)) return;
+
+        var boxW = layer.EffectiveBoxWidth;
+        var boxH = layer.EffectiveBoxHeight;
+        var (boxLeft, boxTop) = TextBoxOrigin(layer, width, height);
+
+        var saved = canvas.Save();
+        canvas.Translate(boxLeft, boxTop);
+
+        DrawTextAt(
+            canvas,
+            layer.Text,
+            layer.TextColor.ToSKColor(),
+            layer.TextSize,
+            layer.Centered,
+            posX: 0,
+            posY: 0,
+            imageWidth: boxW,
+            imageHeight: boxH,
+            layer.Bold,
+            layer.Italic,
+            layer.Outlined,
+            layer.OutlineColor.ToSKColor());
+
+        canvas.RestoreToCount(saved);
+    }
+
+    private static (float Left, float Top) TextBoxOrigin(TextLayer layer, int deviceW, int deviceH)
+    {
+        var boxW = layer.EffectiveBoxWidth;
+        var boxH = layer.EffectiveBoxHeight;
+        if (layer.Centered)
+        {
+            return ((deviceW - boxW) / 2f + layer.PositionX,
+                    (deviceH - boxH) / 2f + layer.PositionY);
+        }
+        return (layer.PositionX, layer.PositionY);
+    }
+
+    private static void DrawSymbolPlaceholder(SKCanvas canvas, SymbolLayer layer, int width, int height)
+    {
+        // Stub renderer: a dashed box with the symbol id (if any) until the
+        // symbol library is wired up.
+        using var paint = new SKPaint
+        {
+            Color = layer.Tint.ToSKColor(),
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 2,
+            IsAntialias = true,
+            PathEffect = SKPathEffect.CreateDash(new float[] { 4, 4 }, 0)
+        };
+
+        var size = Math.Min(width, height) * 0.6f * (float)Math.Max(0.1, layer.Scale);
+        var cx = width / 2f + layer.PositionX;
+        var cy = height / 2f + layer.PositionY;
+        var rect = new SKRect(cx - size / 2f, cy - size / 2f, cx + size / 2f, cy + size / 2f);
+        canvas.DrawRect(rect, paint);
     }
 
     /// <summary>

--- a/ViewModels/TouchButtonSettingsViewModel.cs
+++ b/ViewModels/TouchButtonSettingsViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using LoupixDeck.Models;
 using LoupixDeck.Models.Argus;
+using LoupixDeck.Models.Layers;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Argus;
 using LoupixDeck.Utils;
@@ -15,7 +16,18 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
 {
     public override void Initialize(TouchButton parameter)
     {
+        if (ButtonData != null)
+        {
+            ButtonData.ItemChanged -= ButtonData_ItemChanged;
+        }
+
         ButtonData = parameter;
+
+        if (ButtonData != null)
+        {
+            ButtonData.ItemChanged += ButtonData_ItemChanged;
+            UpdateEditorPreview();
+        }
     }
 
     private readonly IObsController _obs;
@@ -24,10 +36,127 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
     private readonly ISysCommandService _sysCommandService;
     private readonly ICommandBuilder _commandBuilder;
     private readonly IArgusMonitorService _argusMonitor;
+    private readonly IAssetService _assetService;
+    private readonly LoupedeckConfig _config;
 
-    public ICommand SelectImageButtonCommand { get; }
-    public ICommand RemoveImageButtonCommand { get; }
+    public const int EditorCanvasSize = 600;
+    public const int EditorFrameSize = 300;
+    public const int DeviceSize = 90;
+
+    /// <summary>Editor → device coordinate factor (canvas pixels per device pixel).</summary>
+    public static double EditorToDeviceScale => (double)EditorFrameSize / DeviceSize;
+
+
+    public ICommand AddImageLayerCommand { get; }
+    public ICommand AddTextLayerCommand { get; }
+    public ICommand RemoveLayerCommand { get; }
+    public ICommand MoveLayerUpCommand { get; }
+    public ICommand MoveLayerDownCommand { get; }
     public TouchButton ButtonData { get; set; }
+
+    private LayerBase _selectedLayer;
+    public LayerBase SelectedLayer
+    {
+        get => _selectedLayer;
+        set
+        {
+            if (ReferenceEquals(_selectedLayer, value)) return;
+            _selectedLayer = value;
+            OnPropertyChanged(nameof(SelectedLayer));
+            OnPropertyChanged(nameof(SelectedImageLayer));
+            OnPropertyChanged(nameof(SelectedTextLayer));
+            OnPropertyChanged(nameof(ScaleHandlesVisible));
+            UpdateSelectionBounds();
+        }
+    }
+
+    public ImageLayer SelectedImageLayer => _selectedLayer as ImageLayer;
+    public TextLayer SelectedTextLayer => _selectedLayer as TextLayer;
+
+    private SKBitmap _editorPreview;
+
+    public SKBitmap EditorPreview
+    {
+        get => _editorPreview;
+        private set
+        {
+            if (ReferenceEquals(_editorPreview, value)) return;
+            _editorPreview = value;
+            OnPropertyChanged(nameof(EditorPreview));
+        }
+    }
+
+    private Avalonia.Rect _selectionBounds;
+
+    /// <summary>
+    /// On-canvas (editor-preview coordinates) bounds of the currently selected
+    /// layer. Bound to the selection overlay rectangle in the XAML.
+    /// </summary>
+    public Avalonia.Rect SelectionBounds
+    {
+        get => _selectionBounds;
+        private set
+        {
+            if (_selectionBounds == value) return;
+            _selectionBounds = value;
+            OnPropertyChanged(nameof(SelectionBounds));
+            OnPropertyChanged(nameof(SelectionVisible));
+            OnPropertyChanged(nameof(ScaleHandlesVisible));
+            OnPropertyChanged(nameof(SelectionLeft));
+            OnPropertyChanged(nameof(SelectionTop));
+            OnPropertyChanged(nameof(SelectionWidth));
+            OnPropertyChanged(nameof(SelectionHeight));
+            OnPropertyChanged(nameof(HandleNwLeft));
+            OnPropertyChanged(nameof(HandleNwTop));
+            OnPropertyChanged(nameof(HandleNeLeft));
+            OnPropertyChanged(nameof(HandleNeTop));
+            OnPropertyChanged(nameof(HandleSwLeft));
+            OnPropertyChanged(nameof(HandleSwTop));
+            OnPropertyChanged(nameof(HandleSeLeft));
+            OnPropertyChanged(nameof(HandleSeTop));
+            OnPropertyChanged(nameof(HandleNLeft));
+            OnPropertyChanged(nameof(HandleNTop));
+            OnPropertyChanged(nameof(HandleSLeft));
+            OnPropertyChanged(nameof(HandleSTop));
+            OnPropertyChanged(nameof(HandleWLeft));
+            OnPropertyChanged(nameof(HandleWTop));
+            OnPropertyChanged(nameof(HandleELeft));
+            OnPropertyChanged(nameof(HandleETop));
+        }
+    }
+
+    public bool SelectionVisible => _selectedLayer != null &&
+                                    _selectionBounds.Width > 0 && _selectionBounds.Height > 0;
+
+    /// <summary>
+    /// Resize handles are shown for every layer kind. Text layers use them to
+    /// stretch the rendered text via Scale/ScaleY (independent of TextSize).
+    /// </summary>
+    public bool ScaleHandlesVisible => SelectionVisible;
+    public double SelectionLeft => _selectionBounds.X;
+    public double SelectionTop => _selectionBounds.Y;
+    public double SelectionWidth => _selectionBounds.Width;
+    public double SelectionHeight => _selectionBounds.Height;
+
+    public const double HandleSize = 10;
+    private double Hx(double cx) => cx - HandleSize / 2.0;
+    private double Hy(double cy) => cy - HandleSize / 2.0;
+    public double HandleNwLeft => Hx(SelectionLeft);
+    public double HandleNwTop  => Hy(SelectionTop);
+    public double HandleNeLeft => Hx(SelectionLeft + SelectionWidth);
+    public double HandleNeTop  => Hy(SelectionTop);
+    public double HandleSwLeft => Hx(SelectionLeft);
+    public double HandleSwTop  => Hy(SelectionTop + SelectionHeight);
+    public double HandleSeLeft => Hx(SelectionLeft + SelectionWidth);
+    public double HandleSeTop  => Hy(SelectionTop + SelectionHeight);
+    public double HandleNLeft  => Hx(SelectionLeft + SelectionWidth / 2.0);
+    public double HandleNTop   => Hy(SelectionTop);
+    public double HandleSLeft  => Hx(SelectionLeft + SelectionWidth / 2.0);
+    public double HandleSTop   => Hy(SelectionTop + SelectionHeight);
+    public double HandleWLeft  => Hx(SelectionLeft);
+    public double HandleWTop   => Hy(SelectionTop + SelectionHeight / 2.0);
+    public double HandleELeft  => Hx(SelectionLeft + SelectionWidth);
+    public double HandleETop   => Hy(SelectionTop + SelectionHeight / 2.0);
 
     public ObservableCollection<MenuEntry> SystemCommandMenus { get; set; }
     public MenuEntry CurrentMenuEntry { get; set; }
@@ -39,7 +168,9 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         ICoolerControlApiController coolercontrol,
         ISysCommandService sysCommandService,
         ICommandBuilder commandBuilder,
-        IArgusMonitorService argusMonitor)
+        IArgusMonitorService argusMonitor,
+        IAssetService assetService,
+        LoupedeckConfig config)
     {
         _obs = obs;
         _elgatoDevices = elgatoDevices;
@@ -47,9 +178,14 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         _sysCommandService = sysCommandService;
         _commandBuilder = commandBuilder;
         _argusMonitor = argusMonitor;
+        _assetService = assetService;
+        _config = config;
 
-        SelectImageButtonCommand = new AsyncRelayCommand(SelectImageButton_Click);
-        RemoveImageButtonCommand = new RelayCommand(RemoveImageButton_Click);
+        AddImageLayerCommand = new AsyncRelayCommand(AddImageLayer);
+        AddTextLayerCommand = new RelayCommand(AddTextLayer);
+        RemoveLayerCommand = new RelayCommand(RemoveSelectedLayer);
+        MoveLayerUpCommand = new RelayCommand(MoveSelectedLayerUp);
+        MoveLayerDownCommand = new RelayCommand(MoveSelectedLayerDown);
 
         SystemCommandMenus = new ObservableCollection<MenuEntry>();
     }
@@ -293,18 +429,61 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         _elgatoKeyLightMenu.Children.Add(keyLightGroup);
     }
 
-    private async Task SelectImageButton_Click()
+    private async Task AddImageLayer()
     {
-        var result = await FileDialogHelper.OpenFileDialog();
+        var path = await FileDialogHelper.OpenFileDialog();
+        if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
 
-        if (result == null || !File.Exists(result)) return;
+        var relative = _assetService.Import(path);
+        if (string.IsNullOrEmpty(relative)) return;
 
-        ButtonData.Image = SKBitmap.Decode(result);
+        var layer = new ImageLayer
+        {
+            Name = Path.GetFileNameWithoutExtension(path),
+            AssetRelativePath = relative,
+            CachedImage = _assetService.Load(relative)
+        };
+
+        ButtonData.Layers.Add(layer);
+        SelectedLayer = layer;
     }
 
-    private void RemoveImageButton_Click()
+    private void AddTextLayer()
     {
-        ButtonData.Image = null;
+        var layer = new TextLayer
+        {
+            Name = "Text",
+            Text = "Text",
+            BoxWidth = DeviceSize,
+            BoxHeight = DeviceSize
+        };
+        ButtonData.Layers.Add(layer);
+        SelectedLayer = layer;
+    }
+
+    private void RemoveSelectedLayer()
+    {
+        if (_selectedLayer == null) return;
+        var idx = ButtonData.Layers.IndexOf(_selectedLayer);
+        ButtonData.Layers.Remove(_selectedLayer);
+        SelectedLayer = (idx < ButtonData.Layers.Count) ? ButtonData.Layers[idx]
+            : (ButtonData.Layers.Count > 0 ? ButtonData.Layers[^1] : null);
+    }
+
+    private void MoveSelectedLayerUp()
+    {
+        if (_selectedLayer == null) return;
+        var idx = ButtonData.Layers.IndexOf(_selectedLayer);
+        if (idx <= 0) return;
+        ButtonData.Layers.Move(idx, idx - 1);
+    }
+
+    private void MoveSelectedLayerDown()
+    {
+        if (_selectedLayer == null) return;
+        var idx = ButtonData.Layers.IndexOf(_selectedLayer);
+        if (idx < 0 || idx >= ButtonData.Layers.Count - 1) return;
+        ButtonData.Layers.Move(idx, idx + 1);
     }
 
     public void InsertCommand(MenuEntry menuEntry)
@@ -327,26 +506,78 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         try
         {
             b.Command = null;
-            b.Text = string.Empty;
-            b.Image = null;
-            b.TextSize = 16;
-            b.TextPositionX = 0;
-            b.TextPositionY = 0;
-            b.TextColor = Avalonia.Media.Colors.White;
             b.BackColor = Avalonia.Media.Colors.Black;
-            b.OutlineColor = Avalonia.Media.Colors.Black;
-            b.Outlined = false;
-            b.Bold = false;
-            b.Italic = false;
-            b.TextCentered = true;
-            b.ImagePositionX = 0;
-            b.ImagePositionY = 0;
-            b.ImageScale = 100;
+            b.Layers.Clear();
         }
         finally
         {
             b.IgnoreRefresh = false;
         }
         b.Refresh();
+        SelectedLayer = null;
+    }
+
+    private void ButtonData_ItemChanged(object sender, EventArgs e)
+    {
+        // ItemChanged may fire on a background thread (e.g. dynamic-text timer).
+        // Dispatch to the UI thread so the bitmap swap and property notifications
+        // are observed by Avalonia bindings.
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            UpdateEditorPreview();
+            UpdateSelectionBounds();
+        });
+    }
+
+    private void UpdateEditorPreview()
+    {
+        if (ButtonData == null || _config == null) return;
+        EditorPreview = BitmapHelper.RenderEditorCanvas(
+            ButtonData, _config, EditorCanvasSize, EditorFrameSize);
+    }
+
+    /// <summary>
+    /// Re-renders the editor preview + selection overlay without going through
+    /// the TouchButton.ItemChanged pipeline. Called from the code-behind during
+    /// drag while <see cref="TouchButton.IgnoreRefresh"/> is true so the device
+    /// is not flooded with serial writes.
+    /// </summary>
+    public void PreviewRefreshDuringDrag()
+    {
+        UpdateEditorPreview();
+        UpdateSelectionBounds();
+    }
+
+    private void UpdateSelectionBounds()
+    {
+        if (_selectedLayer == null)
+        {
+            SelectionBounds = default;
+            return;
+        }
+
+        var rect = BitmapHelper.GetLayerEditorBounds(
+            _selectedLayer, EditorCanvasSize, EditorFrameSize);
+
+        if (rect == null)
+        {
+            SelectionBounds = default;
+            return;
+        }
+
+        var r = rect.Value;
+        SelectionBounds = new Avalonia.Rect(r.Left, r.Top, r.Width, r.Height);
+    }
+
+    /// <summary>
+    /// Detaches event handlers — called by the View when the dialog closes so the
+    /// (singleton) TouchButton does not keep the (transient) ViewModel alive.
+    /// </summary>
+    public void Cleanup()
+    {
+        if (ButtonData != null)
+        {
+            ButtonData.ItemChanged -= ButtonData_ItemChanged;
+        }
     }
 }

--- a/Views/TouchButtonSettings.axaml
+++ b/Views/TouchButtonSettings.axaml
@@ -7,146 +7,339 @@
     xmlns:ccp="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.ColorPicker"
     xmlns:local="clr-namespace:LoupixDeck"
     xmlns:vm="using:LoupixDeck.ViewModels"
+    xmlns:layers="clr-namespace:LoupixDeck.Models.Layers"
     x:DataType="vm:TouchButtonSettingsViewModel"
     Title="TouchButtonSettings"
-    Height="500"
-    Width="900"
+    Height="820"
+    Width="1280"
     mc:Ignorable="d"
     SystemDecorations="Full"
     CanResize="False">
     <Border BorderThickness="2"
             BorderBrush="DarkGray"
             Padding="4">
-        <Grid RowDefinitions="*,50">
-            <Grid ColumnDefinitions="1.1*,*,*" Grid.Row="0">
-                <StackPanel Grid.Column="0" Margin="10,20,0,0">
-                    <TextBlock Text="Text-Settings" FontWeight="Bold" Margin="0,0,0,5" />
-                    <TextBox Name="TextInputBox" Height="30" Text="{Binding ButtonData.Text}" />
+        <Grid RowDefinitions="*,60">
+            <Grid Grid.Row="0" ColumnDefinitions="240,*,400">
 
-                    <TextBlock Text="Size" />
-                    <Slider Name="TextSize" Minimum="4" Maximum="80" Value="{Binding ButtonData.TextSize}" />
+                <!-- Left: Layer list -->
+                <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto" Margin="6">
+                    <TextBlock Grid.Row="0" Text="Layers" FontWeight="Bold" Margin="0,0,0,5" />
+                    <ListBox Grid.Row="1"
+                             ItemsSource="{Binding ButtonData.Layers}"
+                             SelectedItem="{Binding SelectedLayer, Mode=TwoWay}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="Auto,*">
+                                    <CheckBox Grid.Column="0"
+                                              IsChecked="{Binding Visible, Mode=TwoWay}"
+                                              Margin="0,0,6,0"
+                                              VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding Name}"
+                                               VerticalAlignment="Center" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <UniformGrid Grid.Row="2" Columns="3" Rows="2" Margin="0,6,0,0">
+                        <UniformGrid.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="Margin" Value="2" />
+                                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                <Setter Property="Padding" Value="4,3" />
+                            </Style>
+                        </UniformGrid.Styles>
 
-                    <TextBlock Text="Color" />
-                    <ccp:ColorPicker Name="TextColor" Width="80" HorizontalAlignment="Left"
-                                     Color="{Binding ButtonData.TextColor}" />
+                        <Button Content="+ Image"  Command="{Binding AddImageLayerCommand}" />
+                        <Button Content="+ Text"   Command="{Binding AddTextLayerCommand}"  />
+                        <Button Content="+ Symbol"
+                                IsEnabled="False"
+                                ToolTip.Tip="Symbol-Library coming soon" />
 
-                    <CheckBox Name="BoldCheck" Content="Bold" IsChecked="{Binding ButtonData.Bold}" Margin="0,5,0,0" />
-                    <CheckBox Name="ItalicCheck" Content="Italic" IsChecked="{Binding ButtonData.Italic}" />
+                        <Button Content="▲ Up"     Command="{Binding MoveLayerUpCommand}"   />
+                        <Button Content="▼ Down"   Command="{Binding MoveLayerDownCommand}" />
+                        <Button Content="Remove"   Command="{Binding RemoveLayerCommand}"
+                                Background="#A03030" Foreground="White" />
+                    </UniformGrid>
+                </Grid>
 
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox Name="OutlineCheck" Content="Outlined" IsChecked="{Binding ButtonData.Outlined}"
-                                  Margin="0,0,20,0" />
-                        <ccp:ColorPicker Color="{Binding ButtonData.OutlineColor, Mode=TwoWay}"
-                                         Width="80"
-                                         IsVisible="{Binding ButtonData.Outlined}"
-                                         HorizontalAlignment="Left" />
-                    </StackPanel>
+                <!-- Center: Editor canvas with selection overlay -->
+                <Border Grid.Column="1"
+                        BorderThickness="1" BorderBrush="#444"
+                        Background="#111"
+                        Margin="6"
+                        HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Grid Name="EditorRoot"
+                          Width="600" Height="600"
+                          Background="Transparent"
+                          PointerPressed="Editor_PointerPressed"
+                          PointerMoved="Editor_PointerMoved"
+                          PointerReleased="Editor_PointerReleased">
+                        <Image Width="600" Height="600"
+                               Stretch="None"
+                               IsHitTestVisible="False"
+                               Source="{Binding EditorPreview, Converter={StaticResource SkiaToBitmapConverter}}" />
+                        <Canvas Width="600" Height="600" Background="Transparent">
+                            <Rectangle Stroke="#FF66AAFF"
+                                       StrokeThickness="1.5"
+                                       StrokeDashArray="3,2"
+                                       Fill="Transparent"
+                                       IsHitTestVisible="False"
+                                       IsVisible="{Binding SelectionVisible}"
+                                       Width="{Binding SelectionWidth}"
+                                       Height="{Binding SelectionHeight}"
+                                       Canvas.Left="{Binding SelectionLeft}"
+                                       Canvas.Top="{Binding SelectionTop}" />
+                            <Rectangle Tag="NW" Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleNwLeft}" Canvas.Top="{Binding HandleNwTop}" />
+                            <Rectangle Tag="N"  Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleNLeft}"  Canvas.Top="{Binding HandleNTop}" />
+                            <Rectangle Tag="NE" Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleNeLeft}" Canvas.Top="{Binding HandleNeTop}" />
+                            <Rectangle Tag="W"  Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleWLeft}"  Canvas.Top="{Binding HandleWTop}" />
+                            <Rectangle Tag="E"  Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleELeft}"  Canvas.Top="{Binding HandleETop}" />
+                            <Rectangle Tag="SW" Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleSwLeft}" Canvas.Top="{Binding HandleSwTop}" />
+                            <Rectangle Tag="S"  Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleSLeft}"  Canvas.Top="{Binding HandleSTop}" />
+                            <Rectangle Tag="SE" Width="10" Height="10" Fill="#FF66AAFF" Stroke="White" StrokeThickness="1"
+                                       IsVisible="{Binding ScaleHandlesVisible}"
+                                       Canvas.Left="{Binding HandleSeLeft}" Canvas.Top="{Binding HandleSeTop}" />
+                        </Canvas>
+                    </Grid>
+                </Border>
 
-                    <CheckBox Name="Centered" Content="Centered" IsChecked="{Binding ButtonData.TextCentered}" />
-                    
-                    <StackPanel>
-                        <!-- Text Position X -->
-                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                            <TextBlock Text="Text X:" Width="80" VerticalAlignment="Center" />
-                            <Slider Minimum="-100" Maximum="100"
-                                    Value="{Binding ButtonData.TextPositionX, Mode=TwoWay}"
-                                    IsSnapToTickEnabled="True" TickFrequency="0.1"
-                                    Width="180" />
-                            <TextBlock Text="{Binding ButtonData.TextPositionX}"
-                                       Width="40" Margin="5,0,0,0"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
+                <!-- Right: Tabs (Properties / Commands) -->
+                <TabControl Grid.Column="2" Margin="6">
+                    <TabItem Header="Properties">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel Margin="4">
 
-                        <!-- Text Position Y -->
-                        <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                            <TextBlock Text="Text Y:" Width="80" VerticalAlignment="Center" />
-                            <Slider Minimum="-100" Maximum="100"
-                                    Value="{Binding ButtonData.TextPositionY, Mode=TwoWay}"
-                                    IsSnapToTickEnabled="True" TickFrequency="0.1"
-                                    Width="180" />
-                            <TextBlock Text="{Binding ButtonData.TextPositionY}"
-                                       Width="40" Margin="5,0,0,0"
-                                       VerticalAlignment="Center" />
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
+                                <!-- Button-wide settings -->
+                                <TextBlock Text="Button" FontWeight="Bold" Margin="0,0,0,4" />
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Background:" Width="90" VerticalAlignment="Center" />
+                                    <ccp:ColorPicker Color="{Binding ButtonData.BackColor}"
+                                                     Width="80" HorizontalAlignment="Left" />
+                                </StackPanel>
 
-                <StackPanel Grid.Column="1" Margin="10">
-                    <TextBlock Text="Image-Settings" FontWeight="Bold" Margin="0,0,0,5" />
+                                <Separator Margin="0,4,0,8" />
 
-                    <Image Name="PreviewImage"
-                           Width="120" Height="120"
-                           Stretch="Uniform"
-                           HorizontalAlignment="Left"
-                           Source="{Binding ButtonData.RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                <!-- Per-layer panel -->
+                                <ContentControl Content="{Binding SelectedLayer}">
+                                    <ContentControl.DataTemplates>
 
-                    <StackPanel Orientation="Horizontal" Margin="0,5,0,10">
-                        <Button Content="Select" Width="80"
-                                Command="{Binding SelectImageButtonCommand}" />
-                        <Button Content="Remove" Width="80" Margin="5,0,0,0"
-                                Command="{Binding RemoveImageButtonCommand}" />
-                    </StackPanel>
+                                        <!-- Image layer -->
+                                        <DataTemplate DataType="layers:ImageLayer">
+                                            <StackPanel>
+                                                <TextBlock Text="Image Layer" FontWeight="Bold" Margin="0,0,0,6" />
 
-                    <!-- Scale -->
-                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                        <TextBlock Text="Scale:" Width="80" VerticalAlignment="Center" />
-                        <Slider Minimum="1" Maximum="500"
-                                Value="{Binding ButtonData.ImageScale, Mode=TwoWay}"
-                                IsSnapToTickEnabled="True" TickFrequency="1"
-                                Width="180" />
-                        <TextBlock Text="{Binding ButtonData.ImageScale}"
-                                   Width="40" Margin="5,0,0,0"
-                                   VerticalAlignment="Center" />
-                    </StackPanel>
+                                                <TextBlock Text="Name" />
+                                                <TextBox Text="{Binding Name, Mode=TwoWay}" Margin="0,0,0,6" />
 
-                    <!-- Position X -->
-                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                        <TextBlock Text="Pos X:" Width="80" VerticalAlignment="Center" />
-                        <Slider Minimum="-200" Maximum="200"
-                                Value="{Binding ButtonData.ImagePositionX, Mode=TwoWay}"
-                                IsSnapToTickEnabled="True" TickFrequency="1"
-                                Width="180" />
-                        <TextBlock Text="{Binding ButtonData.ImagePositionX}"
-                                   Width="40" Margin="5,0,0,0"
-                                   VerticalAlignment="Center" />
-                    </StackPanel>
+                                                <TextBlock Text="Asset" />
+                                                <TextBlock Text="{Binding AssetRelativePath}"
+                                                           Foreground="#888" Margin="0,0,0,6" />
 
-                    <!-- Position Y -->
-                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
-                        <TextBlock Text="Pos Y:" Width="80" VerticalAlignment="Center" />
-                        <Slider Minimum="-200" Maximum="200"
-                                Value="{Binding ButtonData.ImagePositionY, Mode=TwoWay}"
-                                IsSnapToTickEnabled="True" TickFrequency="1"
-                                Width="180" />
-                        <TextBlock Text="{Binding ButtonData.ImagePositionY}"
-                                   Width="40" Margin="5,0,0,0"
-                                   VerticalAlignment="Center" />
-                    </StackPanel>
+                                                <TextBlock Text="Position X" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="-200" Maximum="200"
+                                                            Value="{Binding PositionX, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding PositionX}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
 
-                    <!-- Background Color -->
-                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                        <TextBlock Text="Background:" Width="80" VerticalAlignment="Center" />
-                        <ccp:ColorPicker Color="{Binding ButtonData.BackColor}"
-                                         Width="80" HorizontalAlignment="Left" />
-                    </StackPanel>
-                </StackPanel>
+                                                <TextBlock Text="Position Y" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="-200" Maximum="200"
+                                                            Value="{Binding PositionY, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding PositionY}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
 
-                <StackPanel Grid.Column="2" Orientation="Vertical" Margin="20,20,0,0">
-                    <TextBlock Text="System Commands" FontWeight="Bold" Margin="0,0,0,5" />
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                        <TreeView Name="SystemCommandsTreeView" ItemsSource="{Binding SystemCommandMenus}"
-                                  SelectedItem="{Binding CurrentMenuEntry}" MaxHeight="350">
-                            <TreeView.DataTemplates>
-                                <TreeDataTemplate DataType="{x:Type local:Models.MenuEntry}"
-                                                  ItemsSource="{Binding Children}">
-                                    <TextBlock Text="{Binding Name}" PointerPressed="OnPointerPressed" />
-                                </TreeDataTemplate>
-                            </TreeView.DataTemplates>
-                        </TreeView>
-                    </ScrollViewer>
-                </StackPanel>
+                                                <TextBlock Text="Scale" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="0.05" Maximum="5"
+                                                            Value="{Binding Scale, Mode=TwoWay}"
+                                                            TickFrequency="0.05" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding Scale, StringFormat={}{0:0.00}}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+
+                                                <TextBlock Text="Crop (Source-Rect)"
+                                                           FontWeight="Bold" Margin="0,10,0,4"
+                                                           ToolTip.Tip="Hold Alt + drag a handle to crop. Hold Shift to unlock aspect ratio while scaling." />
+                                                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto" Margin="0,0,0,4">
+                                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Left" Width="60" />
+                                                    <NumericUpDown Grid.Row="0" Grid.Column="1"
+                                                                   Value="{Binding SourceRect.Left, Mode=TwoWay}"
+                                                                   Minimum="0" />
+                                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Top" Width="60" />
+                                                    <NumericUpDown Grid.Row="1" Grid.Column="1"
+                                                                   Value="{Binding SourceRect.Top, Mode=TwoWay}"
+                                                                   Minimum="0" />
+                                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Right" Width="60" />
+                                                    <NumericUpDown Grid.Row="2" Grid.Column="1"
+                                                                   Value="{Binding SourceRect.Right, Mode=TwoWay}"
+                                                                   Minimum="0" />
+                                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Bottom" Width="60" />
+                                                    <NumericUpDown Grid.Row="3" Grid.Column="1"
+                                                                   Value="{Binding SourceRect.Bottom, Mode=TwoWay}"
+                                                                   Minimum="0" />
+                                                </Grid>
+                                                <TextBlock Text="(All zeros = use full image)"
+                                                           Foreground="#888" FontStyle="Italic" />
+                                            </StackPanel>
+                                        </DataTemplate>
+
+                                        <!-- Text layer -->
+                                        <DataTemplate DataType="layers:TextLayer">
+                                            <StackPanel>
+                                                <TextBlock Text="Text Layer" FontWeight="Bold" Margin="0,0,0,6" />
+
+                                                <TextBlock Text="Name" />
+                                                <TextBox Text="{Binding Name, Mode=TwoWay}" Margin="0,0,0,6" />
+
+                                                <TextBlock Text="Text" />
+                                                <TextBox Text="{Binding Text, Mode=TwoWay}" Margin="0,0,0,6" />
+
+                                                <TextBlock Text="Size" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="4" Maximum="80"
+                                                            Value="{Binding TextSize, Mode=TwoWay}" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding TextSize}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+
+                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
+                                                    <TextBlock Text="Color:" Width="60" VerticalAlignment="Center" />
+                                                    <ccp:ColorPicker Color="{Binding TextColor, Mode=TwoWay}" Width="80" />
+                                                </StackPanel>
+
+                                                <CheckBox Content="Bold" IsChecked="{Binding Bold, Mode=TwoWay}" />
+                                                <CheckBox Content="Italic" IsChecked="{Binding Italic, Mode=TwoWay}" />
+                                                <CheckBox Content="Centered" IsChecked="{Binding Centered, Mode=TwoWay}" />
+
+                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
+                                                    <CheckBox Content="Outlined" IsChecked="{Binding Outlined, Mode=TwoWay}"
+                                                              Margin="0,0,10,0" />
+                                                    <ccp:ColorPicker Color="{Binding OutlineColor, Mode=TwoWay}"
+                                                                     Width="80"
+                                                                     IsVisible="{Binding Outlined}" />
+                                                </StackPanel>
+
+                                                <TextBlock Text="Position X" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="-100" Maximum="100"
+                                                            Value="{Binding PositionX, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding PositionX}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+
+                                                <TextBlock Text="Position Y" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="-100" Maximum="100"
+                                                            Value="{Binding PositionY, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding PositionY}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+
+                                                <TextBlock Text="Box Width" Margin="0,8,0,0"
+                                                           ToolTip.Tip="Layout area for the text — drag handles in the preview to change." />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="10" Maximum="400"
+                                                            Value="{Binding BoxWidth, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding BoxWidth}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+
+                                                <TextBlock Text="Box Height" />
+                                                <Grid ColumnDefinitions="*,50">
+                                                    <Slider Grid.Column="0"
+                                                            Minimum="10" Maximum="400"
+                                                            Value="{Binding BoxHeight, Mode=TwoWay}"
+                                                            IsSnapToTickEnabled="True" TickFrequency="1" />
+                                                    <TextBlock Grid.Column="1"
+                                                               Text="{Binding BoxHeight}"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Right" />
+                                                </Grid>
+                                            </StackPanel>
+                                        </DataTemplate>
+
+                                        <!-- Symbol layer (stub) -->
+                                        <DataTemplate DataType="layers:SymbolLayer">
+                                            <StackPanel>
+                                                <TextBlock Text="Symbol Layer (stub)" FontWeight="Bold" Margin="0,0,0,6" />
+                                                <TextBlock Text="Name" />
+                                                <TextBox Text="{Binding Name, Mode=TwoWay}" Margin="0,0,0,6" />
+                                                <TextBlock Text="Symbol Id" />
+                                                <TextBox Text="{Binding SymbolId, Mode=TwoWay}" Margin="0,0,0,6"
+                                                         IsEnabled="False"
+                                                         ToolTip.Tip="Will be set by the symbol picker once available." />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ContentControl.DataTemplates>
+                                </ContentControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </TabItem>
+
+                    <TabItem Header="Commands">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            <TreeView Name="SystemCommandsTreeView" ItemsSource="{Binding SystemCommandMenus}"
+                                      SelectedItem="{Binding CurrentMenuEntry}">
+                                <TreeView.DataTemplates>
+                                    <TreeDataTemplate DataType="{x:Type local:Models.MenuEntry}"
+                                                      ItemsSource="{Binding Children}">
+                                        <TextBlock Text="{Binding Name}" PointerPressed="OnPointerPressed" />
+                                    </TreeDataTemplate>
+                                </TreeView.DataTemplates>
+                            </TreeView>
+                        </ScrollViewer>
+                    </TabItem>
+                </TabControl>
             </Grid>
-            <StackPanel Grid.Row="1" Orientation="Vertical">
+
+            <!-- Bottom: command bar -->
+            <StackPanel Grid.Row="1" Orientation="Vertical" Margin="6">
                 <TextBlock Text="Command" FontWeight="Bold" />
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBox Grid.Column="0"

--- a/Views/TouchButtonSettings.axaml.cs
+++ b/Views/TouchButtonSettings.axaml.cs
@@ -1,8 +1,11 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using LoupixDeck.Models;
+using LoupixDeck.Models.Layers;
 using LoupixDeck.Services;
 using LoupixDeck.Utils;
 using LoupixDeck.ViewModels;
@@ -12,6 +15,30 @@ namespace LoupixDeck.Views;
 
 public partial class TouchButtonSettings : Window
 {
+    private enum DragMode { None, Move, Handle }
+
+    private DragMode _dragMode = DragMode.None;
+    private Point _dragStartCanvas;
+
+    // Move-drag state
+    private int _startPosX, _startPosY;
+
+    // Handle-drag state (resize / crop). signX/signY encode which edges this
+    // handle moves: -1 left/top, +1 right/bottom, 0 none.
+    private int _handleSignX, _handleSignY;
+    private bool _isImageLayer;
+
+    // Display rect of the layer in device-pixel space, captured at drag start.
+    // This is the rectangle the renderer draws into (after Fit + Scale + Position).
+    private double _startDrawX, _startDrawY, _startDstW, _startDstH;
+
+    // Source-rect of the image layer (resolved — i.e. full image if SourceRect was Empty).
+    private float _startSrcLeft, _startSrcTop, _startSrcRight, _startSrcBottom;
+    private int _bmpWidth, _bmpHeight;
+
+    private double _startScaleX, _startScaleY;
+    private int _startBoxW, _startBoxH;
+
     public TouchButtonSettings()
     {
         InitializeComponent();
@@ -21,6 +48,11 @@ public partial class TouchButtonSettings : Window
             if (DataContext is IDialogViewModel vm && !vm.DialogResult.Task.IsCompleted)
             {
                 vm.DialogResult.TrySetResult(new DialogResult(false));
+            }
+
+            if (DataContext is TouchButtonSettingsViewModel tbvm)
+            {
+                tbvm.Cleanup();
             }
         };
     }
@@ -36,8 +68,6 @@ public partial class TouchButtonSettings : Window
 
         if (!confirmed) return;
 
-        // Clear AFTER the window is closed — otherwise TwoWay bindings (TextBox,
-        // ColorPicker) write their stale UI values back on focus loss and undo the reset.
         Closed += (_, _) => vm.ClearButton();
         Close();
     }
@@ -73,4 +103,399 @@ public partial class TouchButtonSettings : Window
             e.Handled = true;
         }
     }
+
+    private void Editor_PointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is not TouchButtonSettingsViewModel vm || vm.ButtonData == null) return;
+
+        var pos = e.GetPosition(EditorRoot);
+
+        // 1) Handle hit-test — only meaningful for layers that show handles
+        //    (suppressed for text layers via ScaleHandlesVisible).
+        if (vm.ScaleHandlesVisible && e.Source is Rectangle r && r.Tag is string tag &&
+            TryParseHandleSign(tag, out var sx, out var sy))
+        {
+            BeginHandleDrag(vm, vm.SelectedLayer, sx, sy, pos);
+            e.Handled = true;
+            return;
+        }
+
+        // 2) Selection-rect hit (Move) or layer body hit (Select + Move)
+        var picked = vm.SelectedLayer != null &&
+                     IsInside(pos, vm.SelectionLeft, vm.SelectionTop, vm.SelectionWidth, vm.SelectionHeight)
+            ? vm.SelectedLayer
+            : HitTestLayer(vm, pos);
+
+        if (picked != null)
+        {
+            if (!ReferenceEquals(picked, vm.SelectedLayer))
+                vm.SelectedLayer = picked;
+
+            BeginMoveDrag(vm, picked, pos);
+            e.Handled = true;
+            return;
+        }
+
+        // 3) Nothing hit → deselect
+        vm.SelectedLayer = null;
+    }
+
+    private void Editor_PointerMoved(object sender, PointerEventArgs e)
+    {
+        if (_dragMode == DragMode.None) return;
+        if (DataContext is not TouchButtonSettingsViewModel vm || vm.SelectedLayer == null) return;
+
+        var pos = e.GetPosition(EditorRoot);
+        var canvasToDevice = 1.0 / TouchButtonSettingsViewModel.EditorToDeviceScale;
+
+        switch (_dragMode)
+        {
+            case DragMode.Move:
+            {
+                var dxDev = (int)Math.Round((pos.X - _dragStartCanvas.X) * canvasToDevice);
+                var dyDev = (int)Math.Round((pos.Y - _dragStartCanvas.Y) * canvasToDevice);
+                vm.SelectedLayer.PositionX = _startPosX + dxDev;
+                vm.SelectedLayer.PositionY = _startPosY + dyDev;
+                break;
+            }
+            case DragMode.Handle:
+            {
+                var altHeld   = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+                var shiftHeld = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+                // In device-pixel space:
+                var dxDev = (pos.X - _dragStartCanvas.X) * canvasToDevice;
+                var dyDev = (pos.Y - _dragStartCanvas.Y) * canvasToDevice;
+
+                if (altHeld && _isImageLayer && vm.SelectedLayer is ImageLayer img)
+                    ApplyCrop(img, dxDev, dyDev);
+                else
+                    ApplyResize(vm.SelectedLayer, dxDev, dyDev, shiftHeld);
+                break;
+            }
+        }
+
+        vm.PreviewRefreshDuringDrag();
+        e.Handled = true;
+    }
+
+    private void Editor_PointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        if (_dragMode == DragMode.None) return;
+        _dragMode = DragMode.None;
+
+        if (DataContext is TouchButtonSettingsViewModel vm && vm.ButtonData != null)
+        {
+            vm.ButtonData.IgnoreRefresh = false;
+            vm.ButtonData.Refresh();
+        }
+
+        e.Handled = true;
+    }
+
+    private void BeginMoveDrag(TouchButtonSettingsViewModel vm, LayerBase layer, Point pos)
+    {
+        _dragMode = DragMode.Move;
+        _dragStartCanvas = pos;
+        _startPosX = layer.PositionX;
+        _startPosY = layer.PositionY;
+
+        vm.ButtonData.IgnoreRefresh = true;
+    }
+
+    private void BeginHandleDrag(TouchButtonSettingsViewModel vm, LayerBase layer,
+        int signX, int signY, Point pos)
+    {
+        _dragMode = DragMode.Handle;
+        _dragStartCanvas = pos;
+        _handleSignX = signX;
+        _handleSignY = signY;
+        _isImageLayer = layer is ImageLayer;
+
+        _startPosX = layer.PositionX;
+        _startPosY = layer.PositionY;
+        _startScaleX = layer.EffectiveScaleX;
+        _startScaleY = layer.EffectiveScaleY;
+
+        // Compute the layer's current display rect in device-pixel space.
+        // For image layers we also resolve the effective source rect so the
+        // crop math operates on absolute source pixel coordinates.
+        const int deviceSize = TouchButtonSettingsViewModel.DeviceSize;
+        if (layer is ImageLayer img && img.CachedImage != null)
+        {
+            _bmpWidth = img.CachedImage.Width;
+            _bmpHeight = img.CachedImage.Height;
+
+            if (!img.SourceRect.IsEmpty && img.SourceRect.Width > 0 && img.SourceRect.Height > 0)
+            {
+                _startSrcLeft = img.SourceRect.Left;
+                _startSrcTop = img.SourceRect.Top;
+                _startSrcRight = img.SourceRect.Right;
+                _startSrcBottom = img.SourceRect.Bottom;
+            }
+            else
+            {
+                _startSrcLeft = 0;
+                _startSrcTop = 0;
+                _startSrcRight = _bmpWidth;
+                _startSrcBottom = _bmpHeight;
+            }
+
+            var srcW = _startSrcRight - _startSrcLeft;
+            var srcH = _startSrcBottom - _startSrcTop;
+            var fit = Math.Min(deviceSize / srcW, deviceSize / srcH);
+            _startDstW = srcW * fit * _startScaleX;
+            _startDstH = srcH * fit * _startScaleY;
+            _startDrawX = (deviceSize - _startDstW) / 2.0 + _startPosX;
+            _startDrawY = (deviceSize - _startDstH) / 2.0 + _startPosY;
+        }
+        else if (layer is TextLayer text)
+        {
+            _startBoxW = text.EffectiveBoxWidth;
+            _startBoxH = text.EffectiveBoxHeight;
+            _startDstW = _startBoxW;
+            _startDstH = _startBoxH;
+            if (text.Centered)
+            {
+                _startDrawX = (deviceSize - _startBoxW) / 2.0 + text.PositionX;
+                _startDrawY = (deviceSize - _startBoxH) / 2.0 + text.PositionY;
+            }
+            else
+            {
+                _startDrawX = text.PositionX;
+                _startDrawY = text.PositionY;
+            }
+        }
+        else
+        {
+            // Symbol or other future layer: use the selection bounds.
+            var canvasToDevice = 1.0 / TouchButtonSettingsViewModel.EditorToDeviceScale;
+            var frameOffset = (TouchButtonSettingsViewModel.EditorCanvasSize -
+                               TouchButtonSettingsViewModel.EditorFrameSize) / 2.0;
+            _startDstW = vm.SelectionWidth * canvasToDevice;
+            _startDstH = vm.SelectionHeight * canvasToDevice;
+            _startDrawX = (vm.SelectionLeft - frameOffset) * canvasToDevice;
+            _startDrawY = (vm.SelectionTop - frameOffset) * canvasToDevice;
+        }
+
+        vm.ButtonData.IgnoreRefresh = true;
+    }
+
+    /// <summary>
+    /// OBS-style resize:
+    /// <list type="bullet">
+    /// <item>Edge handles (N/S/E/W) always change only their own axis — the
+    /// orthogonal axis is never touched, so aspect can change naturally.</item>
+    /// <item>Corner handles preserve aspect by default: the drag delta is
+    /// projected onto the line through the pivot in the original handle
+    /// direction, so the corner travels along the box's diagonal regardless
+    /// of which way the mouse moves.</item>
+    /// <item>Holding Shift on a corner unlocks the aspect ratio so X and Y
+    /// follow the pointer independently.</item>
+    /// </list>
+    /// The pivot is the opposite corner/edge midpoint and stays pinned in
+    /// device-pixel space.
+    /// </summary>
+    private void ApplyResize(LayerBase layer, double dxDev, double dyDev, bool shiftHeld)
+    {
+        if (_startDstW <= 0 || _startDstH <= 0) return;
+
+        double factorX, factorY;
+
+        if (_handleSignX != 0 && _handleSignY != 0 && !shiftHeld)
+        {
+            // Corner + aspect lock: project pointer drag onto the original
+            // handle vector. Same factor on both axes ⇒ aspect preserved.
+            var hvx = _handleSignX * _startDstW;
+            var hvy = _handleSignY * _startDstH;
+            var l2 = hvx * hvx + hvy * hvy;
+            if (l2 <= 0) return;
+            var l = Math.Sqrt(l2);
+            var proj = l + (dxDev * hvx + dyDev * hvy) / l;
+            var factor = proj / l;
+            factorX = factor;
+            factorY = factor;
+        }
+        else
+        {
+            // Edge handle, or shift-held corner: per-axis, independent.
+            factorX = _handleSignX == 0 ? 1.0 : (_startDstW + _handleSignX * dxDev) / _startDstW;
+            factorY = _handleSignY == 0 ? 1.0 : (_startDstH + _handleSignY * dyDev) / _startDstH;
+        }
+
+        factorX = Math.Max(0.05, factorX);
+        factorY = Math.Max(0.05, factorY);
+
+        double finalDstW, finalDstH;
+        if (layer is TextLayer text)
+        {
+            // Text layers don't scale the glyphs — they resize their layout box
+            // and re-wrap inside. The handles drive BoxWidth/Height directly.
+            var newBoxW = Math.Max(1, (int)Math.Round(_startBoxW * factorX));
+            var newBoxH = Math.Max(1, (int)Math.Round(_startBoxH * factorY));
+            text.BoxWidth = newBoxW;
+            text.BoxHeight = newBoxH;
+            finalDstW = newBoxW;
+            finalDstH = newBoxH;
+        }
+        else
+        {
+            var newScaleX = Math.Clamp(_startScaleX * factorX, 0.05, 20.0);
+            var newScaleY = Math.Clamp(_startScaleY * factorY, 0.05, 20.0);
+            layer.Scale = newScaleX;
+            layer.ScaleY = newScaleY;
+            finalDstW = (newScaleX / Math.Max(1e-6, _startScaleX)) * _startDstW;
+            finalDstH = (newScaleY / Math.Max(1e-6, _startScaleY)) * _startDstH;
+        }
+
+        // Reposition so the pivot (side opposite to the handle) stays put.
+        UpdatePositionForResize(layer, finalDstW, finalDstH);
+    }
+
+    /// <summary>
+    /// Alt-drag handles: change the image layer's <see cref="ImageLayer.SourceRect"/>
+    /// such that the dragged side of the display rect tracks the pointer while
+    /// the opposite side stays pinned. Scale and position are recomputed so the
+    /// renderer outputs exactly that display rect.
+    /// </summary>
+    private void ApplyCrop(ImageLayer img, double dxDev, double dyDev)
+    {
+        if (_startDstW <= 0 || _startDstH <= 0) return;
+        if (_bmpWidth <= 0 || _bmpHeight <= 0) return;
+
+        var startSrcW = _startSrcRight - _startSrcLeft;
+        var startSrcH = _startSrcBottom - _startSrcTop;
+        if (startSrcW <= 0 || startSrcH <= 0) return;
+
+        // 1) New display rect size for this drag.
+        var newDstW = _startDstW + _handleSignX * dxDev;
+        var newDstH = _startDstH + _handleSignY * dyDev;
+        if (_handleSignX == 0) newDstW = _startDstW;
+        if (_handleSignY == 0) newDstH = _startDstH;
+
+        // Minimum 2 device pixels so the result stays grabable.
+        newDstW = Math.Max(2.0, newDstW);
+        newDstH = Math.Max(2.0, newDstH);
+        // Don't allow the crop to "grow" the image past the original frame.
+        newDstW = Math.Min(_startDstW, newDstW);
+        newDstH = Math.Min(_startDstH, newDstH);
+
+        // 2) New source rect proportional to the displayed shrink.
+        var newSrcW = startSrcW * (newDstW / _startDstW);
+        var newSrcH = startSrcH * (newDstH / _startDstH);
+        var cropX = startSrcW - newSrcW;
+        var cropY = startSrcH - newSrcH;
+
+        float newSrcLeft = _startSrcLeft, newSrcRight = _startSrcRight;
+        float newSrcTop = _startSrcTop, newSrcBottom = _startSrcBottom;
+
+        if (_handleSignX > 0) newSrcRight = _startSrcRight - (float)cropX;
+        else if (_handleSignX < 0) newSrcLeft = _startSrcLeft + (float)cropX;
+
+        if (_handleSignY > 0) newSrcBottom = _startSrcBottom - (float)cropY;
+        else if (_handleSignY < 0) newSrcTop = _startSrcTop + (float)cropY;
+
+        newSrcLeft = Math.Clamp(newSrcLeft, 0, _bmpWidth);
+        newSrcRight = Math.Clamp(newSrcRight, 0, _bmpWidth);
+        newSrcTop = Math.Clamp(newSrcTop, 0, _bmpHeight);
+        newSrcBottom = Math.Clamp(newSrcBottom, 0, _bmpHeight);
+
+        if (newSrcRight - newSrcLeft < 1 || newSrcBottom - newSrcTop < 1) return;
+
+        // 3) Recompute scale + position so the renderer reproduces the desired
+        //    display rect after re-fitting the cropped source.
+        const int deviceSize = TouchButtonSettingsViewModel.DeviceSize;
+        var actualSrcW = newSrcRight - newSrcLeft;
+        var actualSrcH = newSrcBottom - newSrcTop;
+        var newFit = Math.Min(deviceSize / actualSrcW, deviceSize / actualSrcH);
+
+        var newScaleX = newDstW / (actualSrcW * newFit);
+        var newScaleY = newDstH / (actualSrcH * newFit);
+
+        img.SourceRect = new SerializableRect(newSrcLeft, newSrcTop, newSrcRight, newSrcBottom);
+        img.Scale = newScaleX;
+        img.ScaleY = newScaleY;
+
+        UpdatePositionForResize(img, newDstW, newDstH);
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="LayerBase.PositionX"/>/Y so the layer's display rect
+    /// keeps the pivot edge/corner (the side opposite to the dragged handle)
+    /// anchored at its drag-start device-pixel coordinates.
+    /// </summary>
+    private void UpdatePositionForResize(LayerBase layer, double newDstW, double newDstH)
+    {
+        const int deviceSize = TouchButtonSettingsViewModel.DeviceSize;
+
+        // Pivot side fractions inside the rect: 0 = left/top, 1 = right/bottom, 0.5 = centered.
+        double pivotFracX = _handleSignX switch { +1 => 0.0, -1 => 1.0, _ => 0.5 };
+        double pivotFracY = _handleSignY switch { +1 => 0.0, -1 => 1.0, _ => 0.5 };
+
+        var pivotXDev = _startDrawX + pivotFracX * _startDstW;
+        var pivotYDev = _startDrawY + pivotFracY * _startDstH;
+
+        var newDrawX = pivotXDev - pivotFracX * newDstW;
+        var newDrawY = pivotYDev - pivotFracY * newDstH;
+
+        // Non-centered text stores PositionX/Y as the absolute box top-left.
+        // Everything else (images, symbols, centered text) stores them as the
+        // offset from the device-center of the bounding rect.
+        if (layer is TextLayer { Centered: false })
+        {
+            layer.PositionX = (int)Math.Round(newDrawX);
+            layer.PositionY = (int)Math.Round(newDrawY);
+        }
+        else
+        {
+            layer.PositionX = (int)Math.Round(newDrawX - (deviceSize - newDstW) / 2.0);
+            layer.PositionY = (int)Math.Round(newDrawY - (deviceSize - newDstH) / 2.0);
+        }
+    }
+
+    private static bool TryParseHandleSign(string tag, out int signX, out int signY)
+    {
+        switch (tag)
+        {
+            case "NW": signX = -1; signY = -1; return true;
+            case "N":  signX =  0; signY = -1; return true;
+            case "NE": signX =  1; signY = -1; return true;
+            case "W":  signX = -1; signY =  0; return true;
+            case "E":  signX =  1; signY =  0; return true;
+            case "SW": signX = -1; signY =  1; return true;
+            case "S":  signX =  0; signY =  1; return true;
+            case "SE": signX =  1; signY =  1; return true;
+            default:   signX =  0; signY =  0; return false;
+        }
+    }
+
+    /// <summary>
+    /// Topmost-first hit test against the on-canvas bounds of every layer.
+    /// Returns null if the pointer is over empty canvas.
+    /// </summary>
+    private static LayerBase HitTestLayer(TouchButtonSettingsViewModel vm, Point pos)
+    {
+        if (vm.ButtonData?.Layers == null) return null;
+
+        for (var i = vm.ButtonData.Layers.Count - 1; i >= 0; i--)
+        {
+            var layer = vm.ButtonData.Layers[i];
+            if (layer == null || !layer.Visible) continue;
+
+            var rect = BitmapHelper.GetLayerEditorBounds(
+                layer,
+                TouchButtonSettingsViewModel.EditorCanvasSize,
+                TouchButtonSettingsViewModel.EditorFrameSize);
+
+            if (rect == null) continue;
+
+            if (IsInside(pos, rect.Value.Left, rect.Value.Top, rect.Value.Width, rect.Value.Height))
+                return layer;
+        }
+
+        return null;
+    }
+
+    private static bool IsInside(Point p, double x, double y, double w, double h)
+        => p.X >= x && p.X <= x + w && p.Y >= y && p.Y <= y + h;
 }


### PR DESCRIPTION
Replaces the single-image-per-button model with a layered composition: images, text, and (stub) symbols stack on a touch button and are persisted as transform parameters, with originals stored in a content-addressed assets/ folder next to config.json (no more base64-embedded bitmaps).

The editor dialog gets a 600x600 preview with a 300x300 device frame and OBS-style direct manipulation: drag to move, corner/edge handles to resize (aspect-locked by default, Shift unlocks, Alt cropts the image source rect), and text layers resize their layout box (text re-wraps inside) instead of scaling the glyphs.

Config schema bumped to v2; older configs are backed up rather than migrated since the bitmap-per-button format isn't representable as layers.