### PR TITLE
add HWiNFO integration and make integrations opt-in

### DIFF
--- a/Commands/DynamicText/HwInfoSensorCommand.cs
+++ b/Commands/DynamicText/HwInfoSensorCommand.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using LoupixDeck.Commands.Base;
+using LoupixDeck.Services.HwInfo;
+
+namespace LoupixDeck.Commands.DynamicText;
+
+[Command("HwInfo.Sensor", "HWiNFO Sensor", "HWiNFO",
+    parameterTemplate: "({Sensor})",
+    parameterNames: ["Sensor"],
+    parameterTypes: [typeof(string)],
+    Platform = CommandPlatform.Windows)]
+public class HwInfoSensorCommand : IDynamicTextProvider
+{
+    private readonly IHwInfoService _hwInfo;
+
+    public HwInfoSensorCommand(IHwInfoService hwInfo)
+    {
+        _hwInfo = hwInfo;
+    }
+
+    public TimeSpan UpdateInterval => TimeSpan.FromSeconds(2);
+
+    public string GetText(string[] parameters)
+    {
+        if (!_hwInfo.IsAvailable)
+            return "N/A";
+
+        if (parameters is not { Length: >= 1 } || string.IsNullOrWhiteSpace(parameters[0]))
+            return "?";
+
+        if (!TryParseSensorRef(parameters[0], out var sensorId, out var sensorInstance, out var readingId))
+            return "?";
+
+        var sensor = _hwInfo.Sensors.FirstOrDefault(s =>
+            s.SensorId == sensorId && s.SensorInstance == sensorInstance && s.ReadingId == readingId);
+        if (sensor is null)
+            return "?";
+
+        var unit = string.IsNullOrEmpty(sensor.Unit) ? string.Empty : " " + sensor.Unit;
+        return $"{sensor.Value:F1}{unit}";
+    }
+
+    // Reference format: "sensorId:sensorInstance:readingId" — the triple HWiNFO keeps
+    // stable across runs. Values may be decimal or 0x-prefixed hex.
+    private static bool TryParseSensorRef(string raw, out uint sensorId, out uint sensorInstance, out uint readingId)
+    {
+        sensorId = 0;
+        sensorInstance = 0;
+        readingId = 0;
+
+        var parts = raw.Split(':', StringSplitOptions.TrimEntries);
+        if (parts.Length != 3)
+            return false;
+
+        return TryParseUInt(parts[0], out sensorId)
+               && TryParseUInt(parts[1], out sensorInstance)
+               && TryParseUInt(parts[2], out readingId);
+    }
+
+    private static bool TryParseUInt(string text, out uint value)
+    {
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            return uint.TryParse(text.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+        return uint.TryParse(text, out value);
+    }
+
+    public Task Execute(string[] parameters) => Task.CompletedTask;
+}

--- a/Models/HwInfo/HwInfoReadingType.cs
+++ b/Models/HwInfo/HwInfoReadingType.cs
@@ -1,0 +1,16 @@
+namespace LoupixDeck.Models.HwInfo;
+
+// Mirrors SENSOR_READING_TYPE in HWiNFO's shared-memory SDK (HWiNFO Shared Memory Support).
+// Values are the ordinal positions in the original C++ enum and must not be reordered.
+public enum HwInfoReadingType : uint
+{
+    None = 0,
+    Temperature,
+    Voltage,
+    Fan,
+    Current,
+    Power,
+    Clock,
+    Usage,
+    Other,
+}

--- a/Models/HwInfo/HwInfoSensor.cs
+++ b/Models/HwInfo/HwInfoSensor.cs
@@ -1,0 +1,23 @@
+namespace LoupixDeck.Models.HwInfo;
+
+/// <summary>
+/// A single HWiNFO reading, flattened together with its parent sensor group.
+/// <para>
+/// HWiNFO identifies a reading stably across runs by the triple
+/// (<see cref="SensorId"/>, <see cref="SensorInstance"/>, <see cref="ReadingId"/>) —
+/// the section indices themselves are not stable. The HWiNFO.Sensor command
+/// references a reading by exactly that triple.
+/// </para>
+/// </summary>
+public sealed record HwInfoSensor(
+    HwInfoReadingType Type,
+    string SensorName,
+    string Label,
+    string Unit,
+    double Value,
+    double ValueMin,
+    double ValueMax,
+    double ValueAvg,
+    uint SensorId,
+    uint SensorInstance,
+    uint ReadingId);

--- a/Models/LoupedeckConfig.cs
+++ b/Models/LoupedeckConfig.cs
@@ -174,6 +174,31 @@ public class LoupedeckConfig : INotifyPropertyChanged
         }
     }
 
+    // Integration master switches. Default false so the background services
+    // (Argus shared-memory polling, Elgato network discovery) and their commands
+    // stay dormant until the user opts in. A missing key in an older config.json
+    // deserializes to false — backward compatible, no version bump.
+    private bool _argusMonitorEnabled;
+    public bool ArgusMonitorEnabled
+    {
+        get => _argusMonitorEnabled;
+        set { if (_argusMonitorEnabled == value) return; _argusMonitorEnabled = value; OnPropertyChanged(); }
+    }
+
+    private bool _elgatoEnabled;
+    public bool ElgatoEnabled
+    {
+        get => _elgatoEnabled;
+        set { if (_elgatoEnabled == value) return; _elgatoEnabled = value; OnPropertyChanged(); }
+    }
+
+    private bool _hwInfoEnabled;
+    public bool HwInfoEnabled
+    {
+        get => _hwInfoEnabled;
+        set { if (_hwInfoEnabled == value) return; _hwInfoEnabled = value; OnPropertyChanged(); }
+    }
+
     // ObjectCreationHandling.Replace: Newtonsoft otherwise reuses the default
     // collection and appends deserialized items to it — so each save+load round
     // would duplicate every step.

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using LoupixDeck.Models;
 using LoupixDeck.Registry;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Argus;
+using LoupixDeck.Services.HwInfo;
 using LoupixDeck.Services.Audio;
 using LoupixDeck.Services.FolderNavigation;
 using LoupixDeck.Services.SystemPower;
@@ -87,6 +88,7 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton<IElgatoController, ElgatoController>();
         collection.AddSingleton<ICoolerControlApiController, CoolerControlApiController>();
         collection.AddSingleton<IArgusMonitorService, ArgusMonitorService>();
+        collection.AddSingleton<IHwInfoService, HwInfoService>();
         collection.AddSingleton<IDynamicTextManager, DynamicTextManager>();
         collection.AddSingleton<IFolderNavigationService, FolderNavigationService>();
 

--- a/Services/DeviceService.cs
+++ b/Services/DeviceService.cs
@@ -49,7 +49,9 @@ public class LoupedeckDeviceService : IDeviceService
             _elgatoController.InitDeviceAsync(light).GetAwaiter().GetResult();
             elgatoDevices.AddKeyLight(light);
         };
-        _ = _elgatoController.ProbeForElgatoDevices();
+        // Only probe the network for Key Lights when the integration is enabled.
+        if (_config.ElgatoEnabled)
+            _ = _elgatoController.ProbeForElgatoDevices();
     }
 
     public void StartDevice(string devicePort, int deviceBaudrate)

--- a/Services/HwInfo/HwInfoService.cs
+++ b/Services/HwInfo/HwInfoService.cs
@@ -1,0 +1,313 @@
+using System.Buffers.Binary;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using LoupixDeck.Models.HwInfo;
+
+namespace LoupixDeck.Services.HwInfo;
+
+public interface IHwInfoService
+{
+    bool IsAvailable { get; }
+    IReadOnlyList<HwInfoSensor> Sensors { get; }
+    /// <summary>Last status / error line — surfaced in the HWiNFO settings page.</summary>
+    string Diagnostics { get; }
+    event Action SnapshotUpdated;
+    void Start();
+    void Stop();
+}
+
+/// <summary>
+/// Reads sensor data from HWiNFO's shared-memory interface (HWiNFO Shared Memory Support
+/// must be enabled in HWiNFO's settings).
+///
+/// Layout (from the HWiNFO SDK header, default struct packing):
+///   HWiNFO_SENSORS_SHARED_MEM2 header  = 44 bytes
+///     +  0  dwSignature                  u32   ('SiWH' when valid)
+///     +  4  dwVersion                    u32
+///     +  8  dwRevision                   u32
+///     + 12  poll_time                    i64   (__time64_t — bumps every HWiNFO poll)
+///     + 20  dwOffsetOfSensorSection      u32
+///     + 24  dwSizeOfSensorElement        u32
+///     + 28  dwNumSensorElements          u32
+///     + 32  dwOffsetOfReadingSection     u32
+///     + 36  dwSizeOfReadingElement       u32
+///     + 40  dwNumReadingElements         u32
+///   HWiNFO_SENSORS_SENSOR_ELEMENT      (dwSizeOfSensorElement bytes, 264 or larger)
+///     +  0  dwSensorID                   u32
+///     +  4  dwSensorInst                 u32
+///     +  8  szSensorNameOrig             char[128]
+///     +136  szSensorNameUser             char[128]
+///     +264  (newer builds append a UTF-8 copy of the user name)
+///   HWiNFO_SENSORS_READING_ELEMENT     (dwSizeOfReadingElement bytes, 316 or larger)
+///     +  0  tReading                     u32   (SENSOR_READING_TYPE)
+///     +  4  dwSensorIndex                u32   (index into the sensor section)
+///     +  8  dwReadingID                  u32
+///     + 12  szLabelOrig                  char[128]
+///     +140  szLabelUser                  char[128]   (system code page)
+///     +268  szUnit                       char[16]
+///     +284  Value / ValueMin / ValueMax / ValueAvg  4 * f64
+///     +316  (newer builds append UTF-8 copies of szLabelUser / szUnit)
+///
+/// The element is packed (no alignment padding), so the f64 block sits at the fixed
+/// offset 284. Newer HWiNFO builds grow the element by appending UTF-8 string copies
+/// *after* the values — hence reading from a fixed offset, not <c>size - 32</c>.
+/// </summary>
+public sealed class HwInfoService : IHwInfoService, IDisposable
+{
+    private const string MappingName = "Global\\HWiNFO_SENS_SM2";
+
+    // HWiNFO's SDK checks dwSignature == 'SiWH'. That C multi-char literal is the DWORD
+    // 0x53695748 (the bytes lie in memory as 'H','W','i','S').
+    private const uint ValidSignature = 0x53695748;
+
+    private const int HeaderSize = 44;
+    private const int OffsetPollTime = 12;
+    private const int OffsetSensorSection = 20;
+    private const int OffsetSensorElementSize = 24;
+    private const int OffsetSensorCount = 28;
+    private const int OffsetReadingSection = 32;
+    private const int OffsetReadingElementSize = 36;
+    private const int OffsetReadingCount = 40;
+
+    // Offsets inside a sensor element.
+    private const int SensorNameUserOffset = 136;
+    private const int SensorNameLen = 128;
+
+    // Offsets inside a reading element (the trailing doubles are derived from element size).
+    private const int ReadingSensorIndexOffset = 4;
+    private const int ReadingIdOffset = 8;
+    private const int ReadingLabelUserOffset = 140;
+    private const int ReadingLabelLen = 128;
+    private const int ReadingUnitOffset = 268;
+    private const int ReadingUnitLen = 16;
+    // The four f64 values sit immediately after szUnit (the element is packed, no alignment
+    // padding). Newer HWiNFO builds append UTF-8 string copies *after* the values, so the
+    // offset is fixed here rather than derived from the (variable) element size.
+    private const int ReadingValueOffset = ReadingUnitOffset + ReadingUnitLen; // 284
+
+    private const int MaxElements = 4096;
+
+    // Reconnect cadence when HWiNFO (or its shared memory) isn't running.
+    private static readonly TimeSpan ReconnectDelay = TimeSpan.FromSeconds(2);
+    // Poll cadence when connected — only an 8-byte read happens while poll_time is unchanged.
+    private static readonly TimeSpan PollDelay = TimeSpan.FromMilliseconds(250);
+
+    private MemoryMappedFile _mmf;
+    private MemoryMappedViewAccessor _accessor;
+
+    private CancellationTokenSource _cts;
+    private Task _pollTask;
+    private long _lastPollTime;
+
+    private volatile IReadOnlyList<HwInfoSensor> _sensors = Array.Empty<HwInfoSensor>();
+    private volatile string _diagnostics = "Not started";
+
+    public IReadOnlyList<HwInfoSensor> Sensors => _sensors;
+    public bool IsAvailable => _accessor != null;
+    public string Diagnostics => _diagnostics;
+    public event Action SnapshotUpdated;
+
+    private void SetDiagnostics(string text)
+    {
+        if (_diagnostics == text)
+            return;
+        _diagnostics = text;
+        SnapshotUpdated?.Invoke();
+    }
+
+    public void Start()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+        if (_pollTask != null)
+            return;
+
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        _pollTask = Task.Run(() => PollLoop(token), token);
+    }
+
+    public void Stop()
+    {
+        try { _cts?.Cancel(); } catch { }
+        try { _pollTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        _pollTask = null;
+        _cts?.Dispose();
+        _cts = null;
+        Close();
+    }
+
+    public void Dispose() => Stop();
+
+    private async Task PollLoop(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            if (!IsAvailable)
+            {
+                if (!TryOpen())
+                {
+                    SetDiagnostics("Shared memory not found — enable 'Shared Memory Support' in HWiNFO.");
+                    try { await Task.Delay(ReconnectDelay, token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
+                    continue;
+                }
+                _lastPollTime = 0;
+            }
+
+            try
+            {
+                if (TrySnapshot(out var snapshot))
+                {
+                    _sensors = snapshot;
+                    SnapshotUpdated?.Invoke();
+                }
+            }
+            catch (Exception ex)
+            {
+                SetDiagnostics($"Snapshot failed ({ex.GetType().Name}: {ex.Message}).");
+                Console.WriteLine($"HwInfoService: snapshot failed, will reconnect ({ex}).");
+                Close();
+            }
+
+            try { await Task.Delay(PollDelay, token).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private bool TryOpen()
+    {
+        try
+        {
+            _mmf = MemoryMappedFile.OpenExisting(MappingName, MemoryMappedFileRights.Read);
+            // Length 0 maps the entire shared-memory region.
+            _accessor = _mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            return true;
+        }
+        catch
+        {
+            Close();
+            return false;
+        }
+    }
+
+    private void Close()
+    {
+        try { _accessor?.Dispose(); } catch { }
+        try { _mmf?.Dispose(); } catch { }
+        _accessor = null;
+        _mmf = null;
+    }
+
+    private unsafe bool TrySnapshot(out IReadOnlyList<HwInfoSensor> sensors)
+    {
+        sensors = null;
+
+        byte* basePtr = null;
+        _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref basePtr);
+        try
+        {
+            if (basePtr == null)
+                return false;
+
+            var capacity = (int)_accessor.SafeMemoryMappedViewHandle.ByteLength;
+            if (capacity < HeaderSize)
+                return false;
+
+            var view = new ReadOnlySpan<byte>(basePtr, capacity);
+
+            var signature = BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(0, 4));
+            if (signature != ValidSignature)
+            {
+                SetDiagnostics($"Bad signature 0x{signature:X8} (expected 0x{ValidSignature:X8}).");
+                return false;
+            }
+
+            var pollTime = BinaryPrimitives.ReadInt64LittleEndian(view.Slice(OffsetPollTime, 8));
+            if (pollTime == _lastPollTime)
+                return false;
+
+            var sensorOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetSensorSection, 4));
+            var sensorElemSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetSensorElementSize, 4));
+            var sensorCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetSensorCount, 4));
+            var readingOffset = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetReadingSection, 4));
+            var readingElemSize = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetReadingElementSize, 4));
+            var readingCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(view.Slice(OffsetReadingCount, 4));
+
+            var headerInfo = $"cap={capacity} sOff={sensorOffset} sSize={sensorElemSize} sCnt={sensorCount} " +
+                             $"rOff={readingOffset} rSize={readingElemSize} rCnt={readingCount}";
+
+            if (sensorElemSize < SensorNameUserOffset + SensorNameLen ||
+                readingElemSize < ReadingUnitOffset + ReadingUnitLen + 32)
+            {
+                SetDiagnostics($"Unexpected element size — {headerInfo}");
+                return false;
+            }
+            if (sensorCount is < 0 or > MaxElements || readingCount is < 0 or > MaxElements)
+            {
+                SetDiagnostics($"Element count out of range — {headerInfo}");
+                return false;
+            }
+            if (sensorOffset + (long)sensorCount * sensorElemSize > capacity ||
+                readingOffset + (long)readingCount * readingElemSize > capacity)
+            {
+                SetDiagnostics($"Section exceeds mapping — {headerInfo}");
+                return false;
+            }
+
+            // Parent sensor section: (id, instance, user name) per group.
+            var sensorGroups = new (uint Id, uint Instance, string Name)[sensorCount];
+            for (var i = 0; i < sensorCount; i++)
+            {
+                var elem = view.Slice(sensorOffset + i * sensorElemSize, sensorElemSize);
+                sensorGroups[i] = (
+                    BinaryPrimitives.ReadUInt32LittleEndian(elem.Slice(0, 4)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(elem.Slice(4, 4)),
+                    ReadAnsiString(elem.Slice(SensorNameUserOffset, SensorNameLen)));
+            }
+
+            var list = new List<HwInfoSensor>(readingCount);
+            for (var i = 0; i < readingCount; i++)
+            {
+                var elem = view.Slice(readingOffset + i * readingElemSize, readingElemSize);
+
+                var type = (HwInfoReadingType)BinaryPrimitives.ReadUInt32LittleEndian(elem.Slice(0, 4));
+                var sensorIndex = (int)BinaryPrimitives.ReadUInt32LittleEndian(elem.Slice(ReadingSensorIndexOffset, 4));
+                var readingId = BinaryPrimitives.ReadUInt32LittleEndian(elem.Slice(ReadingIdOffset, 4));
+                var label = ReadAnsiString(elem.Slice(ReadingLabelUserOffset, ReadingLabelLen));
+                var unit = ReadAnsiString(elem.Slice(ReadingUnitOffset, ReadingUnitLen));
+                var value = BinaryPrimitives.ReadDoubleLittleEndian(elem.Slice(ReadingValueOffset, 8));
+                var valueMin = BinaryPrimitives.ReadDoubleLittleEndian(elem.Slice(ReadingValueOffset + 8, 8));
+                var valueMax = BinaryPrimitives.ReadDoubleLittleEndian(elem.Slice(ReadingValueOffset + 16, 8));
+                var valueAvg = BinaryPrimitives.ReadDoubleLittleEndian(elem.Slice(ReadingValueOffset + 24, 8));
+
+                var group = sensorIndex >= 0 && sensorIndex < sensorCount
+                    ? sensorGroups[sensorIndex]
+                    : (Id: 0u, Instance: 0u, Name: string.Empty);
+
+                list.Add(new HwInfoSensor(
+                    type, group.Name, label, unit,
+                    value, valueMin, valueMax, valueAvg,
+                    group.Id, group.Instance, readingId));
+            }
+
+            _lastPollTime = pollTime;
+            sensors = list;
+            SetDiagnostics($"OK — {list.Count} readings, {sensorCount} sensors ({headerInfo}).");
+            return true;
+        }
+        finally
+        {
+            _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+        }
+    }
+
+    private static string ReadAnsiString(ReadOnlySpan<byte> bytes)
+    {
+        // NUL-terminated single-byte string. Latin1 covers HWiNFO's degree sign etc.
+        var end = bytes.IndexOf((byte)0);
+        if (end < 0)
+            end = bytes.Length;
+        return Encoding.Latin1.GetString(bytes.Slice(0, end));
+    }
+}

--- a/ViewModels/Base/Enums.cs
+++ b/ViewModels/Base/Enums.cs
@@ -9,6 +9,7 @@ public enum SettingsView
     Elgato,
     CoolerControl,
     Argus,
+    HwInfo,
     Theme,
     About
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using LoupixDeck.Controllers;
 using LoupixDeck.Models;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Argus;
+using LoupixDeck.Services.HwInfo;
 using LoupixDeck.Services.SystemPower;
 using LoupixDeck.ViewModels.Base;
 using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
@@ -44,8 +45,10 @@ public class MainWindowViewModel : ViewModelBase
         IDialogService dialogService,
         ISysCommandService sysCommandService,
         IArgusMonitorService argusMonitorService,
+        IHwInfoService hwInfoService,
         IDynamicTextManager dynamicTextManager,
         ISystemPowerService powerService,
+        LoupedeckConfig config,
         LoupixDeck.Registry.DeviceRegistry.DeviceInfo deviceInfo)
     {
         LoupedeckController = loupedeck;
@@ -53,7 +56,15 @@ public class MainWindowViewModel : ViewModelBase
         _dynamicTextManager = dynamicTextManager;
 
         sysCommandService.Initialize();
-        argusMonitorService.Start();
+
+        // Only spin up the Argus poll loop when the integration is enabled.
+        // The Settings dialog can start/stop it later at runtime.
+        if (config.ArgusMonitorEnabled)
+            argusMonitorService.Start();
+
+        // Same for the HWiNFO shared-memory poll loop.
+        if (config.HwInfoEnabled)
+            hwInfoService.Start();
 
         // Auto-clear the device while the host is suspended, restore on wake.
         // Both handlers must hop to the UI thread because they touch ObservableCollections

--- a/ViewModels/RotaryButtonSettingsViewModel.cs
+++ b/ViewModels/RotaryButtonSettingsViewModel.cs
@@ -21,6 +21,7 @@ public class RotaryButtonSettingsViewModel : DialogViewModelBase<RotaryButton, D
     private readonly ElgatoDevices _elgatoDevices;
     private readonly ISysCommandService _sysCommandService;
     private readonly ICommandBuilder _commandBuilder;
+    private readonly LoupedeckConfig _config;
 
     public RotaryButton ButtonData { get; set; }
 
@@ -31,12 +32,14 @@ public class RotaryButtonSettingsViewModel : DialogViewModelBase<RotaryButton, D
     public RotaryButtonSettingsViewModel(IObsController obs,
         ElgatoDevices elgatoDevices,
         ISysCommandService sysCommandService,
-        ICommandBuilder commandBuilder)
+        ICommandBuilder commandBuilder,
+        LoupedeckConfig config)
     {
         _obs = obs;
         _elgatoDevices = elgatoDevices;
         _sysCommandService = sysCommandService;
         _commandBuilder = commandBuilder;
+        _config = config;
 
         SystemCommandMenus = new ObservableCollection<MenuEntry>();
     }
@@ -51,7 +54,8 @@ public class RotaryButtonSettingsViewModel : DialogViewModelBase<RotaryButton, D
         CreatePagesMenu();
         CreateDeviceControlMenu();
         var obsTask = CreateObsMenu();
-        CreateElgatoMenu();
+        if (_config.ElgatoEnabled)
+            CreateElgatoMenu();
         await obsTask;
     }
 

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -9,8 +9,10 @@ using LoupixDeck.LoupedeckDevice.Device;
 using LoupixDeck.Models;
 using LoupixDeck.Models.Argus;
 using LoupixDeck.Models.Converter;
+using LoupixDeck.Models.HwInfo;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Argus;
+using LoupixDeck.Services.HwInfo;
 using LoupixDeck.Utils;
 using LoupixDeck.ViewModels.Base;
 using Newtonsoft.Json.Linq;
@@ -26,6 +28,7 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
     private readonly IElgatoController _elgatoController;
     private readonly IPageManager _pageManager;
     private readonly IArgusMonitorService _argusMonitor;
+    private readonly IHwInfoService _hwInfo;
     private readonly IDialogService _dialogService;
     public ElgatoDevices ElgatoDevices { get; }
 
@@ -61,6 +64,7 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
         ElgatoDevices elgatoDevices,
         IPageManager pageManager,
         IArgusMonitorService argusMonitor,
+        IHwInfoService hwInfo,
         IDialogService dialogService)
     {
         Config = config;
@@ -69,6 +73,7 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
         ElgatoDevices = elgatoDevices ?? new ElgatoDevices();
         _pageManager = pageManager;
         _argusMonitor = argusMonitor;
+        _hwInfo = hwInfo;
         _dialogService = dialogService;
 
         SaveObsCommand = new RelayCommand(SaveObs);
@@ -146,6 +151,12 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
             _argusMonitor.SnapshotUpdated += OnArgusSnapshotUpdated;
             // Refresh on UI thread but lightweight — only reads the volatile snapshot field.
             Dispatcher.UIThread.Post(RefreshArgusSnapshot);
+        }
+
+        if (_hwInfo != null)
+        {
+            _hwInfo.SnapshotUpdated += OnHwInfoSnapshotUpdated;
+            Dispatcher.UIThread.Post(RefreshHwInfoSnapshot);
         }
 
         // Device info call blocks on a serial round-trip — push it off the UI thread.
@@ -380,6 +391,23 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
 
     // ───────── Elgato ─────────
 
+    /// <summary>
+    /// Master switch for the Elgato integration. Enabling it kicks off a discovery
+    /// probe immediately so Key Lights show up without waiting for the next app start.
+    /// </summary>
+    public bool ElgatoEnabled
+    {
+        get => Config.ElgatoEnabled;
+        set
+        {
+            if (Config.ElgatoEnabled == value) return;
+            Config.ElgatoEnabled = value;
+            OnPropertyChanged();
+            if (value)
+                _ = _elgatoController.ProbeForElgatoDevices();
+        }
+    }
+
     private bool _isScanningElgato;
     public bool IsScanningElgato
     {
@@ -471,6 +499,26 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
 
     // ───────── Argus ─────────
 
+    /// <summary>
+    /// Master switch for the Argus Monitor integration. Toggling it starts/stops the
+    /// shared-memory poll loop right away so the status reflects the change live.
+    /// </summary>
+    public bool ArgusMonitorEnabled
+    {
+        get => Config.ArgusMonitorEnabled;
+        set
+        {
+            if (Config.ArgusMonitorEnabled == value) return;
+            Config.ArgusMonitorEnabled = value;
+            OnPropertyChanged();
+            if (value)
+                _argusMonitor?.Start();
+            else
+                _argusMonitor?.Stop();
+            RefreshArgusSnapshot();
+        }
+    }
+
     public ObservableCollection<ArgusSensor> ArgusSensors { get; } = [];
 
     public string ArgusStatusText => (_argusMonitor?.IsAvailable ?? false) ? "Reading" : "Not running";
@@ -492,6 +540,53 @@ public class SettingsViewModel : DialogViewModelBase<DialogResult>
         if (_argusMonitor?.Sensors == null) return;
         foreach (var s in _argusMonitor.Sensors.Take(60))
             ArgusSensors.Add(s);
+    }
+
+    // ───────── HWiNFO ─────────
+
+    /// <summary>
+    /// Master switch for the HWiNFO integration. Toggling it starts/stops the
+    /// shared-memory poll loop right away so the status reflects the change live.
+    /// </summary>
+    public bool HwInfoEnabled
+    {
+        get => Config.HwInfoEnabled;
+        set
+        {
+            if (Config.HwInfoEnabled == value) return;
+            Config.HwInfoEnabled = value;
+            OnPropertyChanged();
+            if (value)
+                _hwInfo?.Start();
+            else
+                _hwInfo?.Stop();
+            RefreshHwInfoSnapshot();
+        }
+    }
+
+    public ObservableCollection<HwInfoSensor> HwInfoSensors { get; } = [];
+
+    public string HwInfoStatusText => (_hwInfo?.IsAvailable ?? false) ? "Reading" : "Not running";
+    public bool HwInfoStatusOk => _hwInfo?.IsAvailable ?? false;
+    public bool HwInfoStatusNeutral => !HwInfoStatusOk;
+    public string HwInfoDiagnostics => _hwInfo?.Diagnostics ?? string.Empty;
+
+    private void OnHwInfoSnapshotUpdated()
+    {
+        Dispatcher.UIThread.Post(RefreshHwInfoSnapshot);
+    }
+
+    private void RefreshHwInfoSnapshot()
+    {
+        OnPropertyChanged(nameof(HwInfoStatusText));
+        OnPropertyChanged(nameof(HwInfoStatusOk));
+        OnPropertyChanged(nameof(HwInfoStatusNeutral));
+        OnPropertyChanged(nameof(HwInfoDiagnostics));
+
+        HwInfoSensors.Clear();
+        if (_hwInfo?.Sensors == null) return;
+        foreach (var s in _hwInfo.Sensors.Take(60))
+            HwInfoSensors.Add(s);
     }
 
     // ───────── Theme ─────────

--- a/ViewModels/SimpleButtonSettingsViewModel.cs
+++ b/ViewModels/SimpleButtonSettingsViewModel.cs
@@ -17,6 +17,7 @@ public class SimpleButtonSettingsViewModel : DialogViewModelBase<SimpleButton, D
     private readonly ElgatoDevices _elgatoDevices;
     private readonly ISysCommandService _sysCommandService;
     private readonly ICommandBuilder _commandBuilder;
+    private readonly LoupedeckConfig _config;
 
     public SimpleButton ButtonData { get; set; }
 
@@ -27,12 +28,14 @@ public class SimpleButtonSettingsViewModel : DialogViewModelBase<SimpleButton, D
     public MenuEntry CurrentMenuEntry { get; set; }
 
     public SimpleButtonSettingsViewModel(IObsController obs, ElgatoDevices elgatoDevices,
-        ISysCommandService sysCommandService, ICommandBuilder commandBuilder)
+        ISysCommandService sysCommandService, ICommandBuilder commandBuilder,
+        LoupedeckConfig config)
     {
         _obs = obs;
         _elgatoDevices = elgatoDevices;
         _sysCommandService = sysCommandService;
         _commandBuilder = commandBuilder;
+        _config = config;
 
         SystemCommandMenus = new ObservableCollection<MenuEntry>();
     }
@@ -47,7 +50,8 @@ public class SimpleButtonSettingsViewModel : DialogViewModelBase<SimpleButton, D
         CreatePagesMenu();
         CreateDeviceControlMenu();
         var obsTask = CreateObsMenu();
-        CreateElgatoMenu();
+        if (_config.ElgatoEnabled)
+            CreateElgatoMenu();
         await obsTask;
     }
 

--- a/ViewModels/TouchButtonSettingsViewModel.cs
+++ b/ViewModels/TouchButtonSettingsViewModel.cs
@@ -4,9 +4,11 @@ using LoupixDeck.LoupedeckDevice;
 using LoupixDeck.Models;
 using LoupixDeck.Models.Argus;
 using LoupixDeck.Models.Converter;
+using LoupixDeck.Models.HwInfo;
 using LoupixDeck.Models.Layers;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Argus;
+using LoupixDeck.Services.HwInfo;
 using LoupixDeck.Utils;
 using LoupixDeck.ViewModels.Base;
 using SkiaSharp;
@@ -42,6 +44,7 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
     private readonly ISysCommandService _sysCommandService;
     private readonly ICommandBuilder _commandBuilder;
     private readonly IArgusMonitorService _argusMonitor;
+    private readonly IHwInfoService _hwInfo;
     private readonly IAssetService _assetService;
     private readonly IDialogService _dialogService;
     private readonly LoupedeckConfig _config;
@@ -193,6 +196,7 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         ISysCommandService sysCommandService,
         ICommandBuilder commandBuilder,
         IArgusMonitorService argusMonitor,
+        IHwInfoService hwInfo,
         IAssetService assetService,
         IDialogService dialogService,
         LoupedeckConfig config)
@@ -203,6 +207,7 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         _sysCommandService = sysCommandService;
         _commandBuilder = commandBuilder;
         _argusMonitor = argusMonitor;
+        _hwInfo = hwInfo;
         _assetService = assetService;
         _dialogService = dialogService;
         _config = config;
@@ -237,10 +242,14 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
         // and populate scenes/modes asynchronously, so order stays stable
         // while both network calls run in parallel.
         var obsTask = CreateObsMenu();
-        CreateElgatoMenu();
+        if (_config.ElgatoEnabled)
+            CreateElgatoMenu();
         var coolerTask = CreateCoolerControlMenu();
         CreateDynamicTextMenu();
-        CreateArgusMonitorMenu();
+        if (_config.ArgusMonitorEnabled)
+            CreateArgusMonitorMenu();
+        if (_config.HwInfoEnabled)
+            CreateHwInfoMenu();
         CreateAudioMenu();
 
         await Task.WhenAll(obsTask, coolerTask);
@@ -292,6 +301,50 @@ public class TouchButtonSettingsViewModel : DialogViewModelBase<TouchButton, Dia
                     parameters: new Dictionary<string, string>
                     {
                         { "Sensor", $"{sensor.Type}:{sensor.SensorIndex}" }
+                    }));
+            }
+
+            groupMenu.Children.Add(typeMenu);
+        }
+
+        SystemCommandMenus.Add(groupMenu);
+    }
+
+    private void CreateHwInfoMenu()
+    {
+        var groupMenu = new MenuEntry("HWiNFO", string.Empty);
+
+        var sensors = _hwInfo.Sensors;
+        if (!_hwInfo.IsAvailable || sensors.Count == 0)
+        {
+            groupMenu.Children.Add(new MenuEntry("HWiNFO not available", string.Empty));
+            SystemCommandMenus.Add(groupMenu);
+            return;
+        }
+
+        // HWiNFO's natural grouping is the parent sensor (CPU, GPU, a drive, …).
+        foreach (var sensorGroup in sensors
+                     .GroupBy(s => new { s.SensorId, s.SensorInstance, s.SensorName })
+                     .OrderBy(g => g.Key.SensorName))
+        {
+            var name = string.IsNullOrWhiteSpace(sensorGroup.Key.SensorName)
+                ? $"Sensor 0x{sensorGroup.Key.SensorId:X}"
+                : sensorGroup.Key.SensorName;
+            var typeMenu = new MenuEntry(name, string.Empty);
+
+            foreach (var sensor in sensorGroup.OrderBy(s => s.ReadingId))
+            {
+                var label = string.IsNullOrWhiteSpace(sensor.Label)
+                    ? $"#{sensor.ReadingId}"
+                    : sensor.Label;
+
+                typeMenu.Children.Add(new MenuEntry(
+                    label,
+                    "HwInfo.Sensor",
+                    parentName: null,
+                    parameters: new Dictionary<string, string>
+                    {
+                        { "Sensor", $"{sensor.SensorId}:{sensor.SensorInstance}:{sensor.ReadingId}" }
                     }));
             }
 

--- a/Views/Settings.axaml
+++ b/Views/Settings.axaml
@@ -7,6 +7,7 @@
         xmlns:cnv="clr-namespace:LoupixDeck.Models.Converter"
         xmlns:m="clr-namespace:LoupixDeck.Models"
         xmlns:argus="clr-namespace:LoupixDeck.Models.Argus"
+        xmlns:hwinfo="clr-namespace:LoupixDeck.Models.HwInfo"
         x:Class="LoupixDeck.Views.Settings"
         x:DataType="vm:SettingsViewModel"
         x:Name="SettingsWindow"
@@ -89,6 +90,15 @@
                             <Border Grid.Column="0" Classes="nav-accent" />
                             <TextBlock Grid.Column="1" Classes="nav-icon" Text="&#xF12E;" Margin="6,0,0,0"/>
                             <TextBlock Grid.Column="2" Classes="nav-label" Text="Argus Monitor" />
+                        </Grid>
+                    </Button>
+                    <Button Classes="nav" Classes.active="{Binding CurrentView, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=HwInfo}"
+                            Command="{Binding NavigateCommand}" CommandParameter="{x:Static bs:SettingsView.HwInfo}"
+                            IsVisible="{Binding IsWindows}">
+                        <Grid ColumnDefinitions="6,Auto,*">
+                            <Border Grid.Column="0" Classes="nav-accent" />
+                            <TextBlock Grid.Column="1" Classes="nav-icon" Text="&#xF035B;" Margin="6,0,0,0"/>
+                            <TextBlock Grid.Column="2" Classes="nav-label" Text="HWiNFO" />
                         </Grid>
                     </Button>
 
@@ -458,42 +468,50 @@
 
                 <!-- ====== Elgato ====== -->
                 <StackPanel IsVisible="{Binding CurrentView, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Elgato}">
-                    <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Grid.Column="0" Classes="page-title" Text="Elgato Key Lights" />
-                        <Button Grid.Column="1" Content="Rescan" Command="{Binding RescanElgatoCommand}" />
-                    </Grid>
+                    <TextBlock Classes="page-title" Text="Elgato Key Lights" />
 
-                    <ItemsControl ItemsSource="{Binding ElgatoDevices.KeyLights}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="m:KeyLight">
-                                <Border Classes="card">
-                                    <StackPanel>
-                                        <Grid ColumnDefinitions="*,Auto">
-                                            <StackPanel Grid.Column="0">
-                                                <TextBlock Classes="card-title" Text="{Binding DisplayName}" />
-                                                <TextBlock Classes="label" Text="{Binding Address}" />
-                                            </StackPanel>
-                                            <Button Grid.Column="1" Content="Power"
-                                                    Command="{Binding $parent[Window].DataContext.ToggleKeyLightCommand}"
-                                                    CommandParameter="{Binding}" />
-                                        </Grid>
-                                        <Grid ColumnDefinitions="100,*" RowDefinitions="Auto,Auto" Margin="0,8,0,0">
-                                            <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="Brightness" VerticalAlignment="Center"/>
-                                            <Slider Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Width="300"
-                                                    HorizontalAlignment="Left" Value="{Binding Brightness, Mode=TwoWay}" />
-                                            <TextBlock Grid.Row="1" Grid.Column="0" Classes="label" Text="Temperature" VerticalAlignment="Center" Margin="0,8,0,0"/>
-                                            <Slider Grid.Row="1" Grid.Column="1" Minimum="143" Maximum="344" Width="300"
-                                                    HorizontalAlignment="Left" Value="{Binding Temperature, Mode=TwoWay}" Margin="0,8,0,0"/>
-                                        </Grid>
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-
-                    <Border Classes="card" IsVisible="{Binding HasNoElgatoLights}">
-                        <TextBlock Classes="hint" Text="No Key Lights found. Make sure they're on the same network and click Rescan." />
+                    <Border Classes="card">
+                        <CheckBox Content="Enable Elgato Key Light integration"
+                                  IsChecked="{Binding ElgatoEnabled, Mode=TwoWay}"
+                                  ToolTip.Tip="When off, Key Light discovery does not run and Elgato commands are hidden from the button command menus." />
                     </Border>
+
+                    <StackPanel IsEnabled="{Binding ElgatoEnabled}">
+                        <Button Content="Rescan" HorizontalAlignment="Right" Margin="0,0,0,8"
+                                Command="{Binding RescanElgatoCommand}" />
+
+                        <ItemsControl ItemsSource="{Binding ElgatoDevices.KeyLights}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="m:KeyLight">
+                                    <Border Classes="card">
+                                        <StackPanel>
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <StackPanel Grid.Column="0">
+                                                    <TextBlock Classes="card-title" Text="{Binding DisplayName}" />
+                                                    <TextBlock Classes="label" Text="{Binding Address}" />
+                                                </StackPanel>
+                                                <Button Grid.Column="1" Content="Power"
+                                                        Command="{Binding $parent[Window].DataContext.ToggleKeyLightCommand}"
+                                                        CommandParameter="{Binding}" />
+                                            </Grid>
+                                            <Grid ColumnDefinitions="100,*" RowDefinitions="Auto,Auto" Margin="0,8,0,0">
+                                                <TextBlock Grid.Row="0" Grid.Column="0" Classes="label" Text="Brightness" VerticalAlignment="Center"/>
+                                                <Slider Grid.Row="0" Grid.Column="1" Minimum="0" Maximum="100" Width="300"
+                                                        HorizontalAlignment="Left" Value="{Binding Brightness, Mode=TwoWay}" />
+                                                <TextBlock Grid.Row="1" Grid.Column="0" Classes="label" Text="Temperature" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                                                <Slider Grid.Row="1" Grid.Column="1" Minimum="143" Maximum="344" Width="300"
+                                                        HorizontalAlignment="Left" Value="{Binding Temperature, Mode=TwoWay}" Margin="0,8,0,0"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <Border Classes="card" IsVisible="{Binding HasNoElgatoLights}">
+                            <TextBlock Classes="hint" Text="No Key Lights found. Make sure they're on the same network and click Rescan." />
+                        </Border>
+                    </StackPanel>
                 </StackPanel>
 
                 <!-- ====== CoolerControl ====== -->
@@ -576,10 +594,16 @@
         <!-- ====== Argus (outside ScrollViewer for bounded height) ====== -->
         <Grid Grid.Column="1" Margin="24,16,4,16"
               IsVisible="{Binding CurrentView, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Argus}"
-              RowDefinitions="Auto,Auto,*">
+              RowDefinitions="Auto,Auto,Auto,*">
             <TextBlock Grid.Row="0" Classes="page-title" Text="Argus Monitor" />
 
             <Border Grid.Row="1" Classes="card">
+                <CheckBox Content="Enable Argus Monitor integration"
+                          IsChecked="{Binding ArgusMonitorEnabled, Mode=TwoWay}"
+                          ToolTip.Tip="When off, the shared-memory poll loop is stopped and Argus sensor commands are hidden from the button command menus." />
+            </Border>
+
+            <Border Grid.Row="2" Classes="card" IsEnabled="{Binding ArgusMonitorEnabled}">
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Grid.Column="0" Classes="card-title" Text="Status" />
                     <Border Grid.Column="1" Classes="pill"
@@ -590,13 +614,62 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Row="2" Classes="card">
+            <Border Grid.Row="3" Classes="card" IsEnabled="{Binding ArgusMonitorEnabled}">
                 <Grid RowDefinitions="Auto,*">
                     <TextBlock Grid.Row="0" Classes="card-title" Text="Sensors (first 60)" />
                     <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0">
                         <ItemsControl ItemsSource="{Binding ArgusSensors}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate DataType="argus:ArgusSensor">
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,2">
+                                        <TextBlock Grid.Column="0" Text="{Binding Label}" />
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
+                                            <TextBlock Text="{Binding Value, StringFormat=F1}" Classes="value" />
+                                            <TextBlock Text="{Binding Unit}" Classes="label" />
+                                        </StackPanel>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- ====== HWiNFO (outside ScrollViewer for bounded height) ====== -->
+        <Grid Grid.Column="1" Margin="24,16,4,16"
+              IsVisible="{Binding CurrentView, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=HwInfo}"
+              RowDefinitions="Auto,Auto,Auto,*">
+            <TextBlock Grid.Row="0" Classes="page-title" Text="HWiNFO" />
+
+            <Border Grid.Row="1" Classes="card">
+                <CheckBox Content="Enable HWiNFO integration"
+                          IsChecked="{Binding HwInfoEnabled, Mode=TwoWay}"
+                          ToolTip.Tip="When off, the shared-memory poll loop is stopped and HWiNFO sensor commands are hidden from the button command menus. Requires 'Shared Memory Support' to be enabled in HWiNFO." />
+            </Border>
+
+            <Border Grid.Row="2" Classes="card" IsEnabled="{Binding HwInfoEnabled}">
+                <StackPanel>
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0" Classes="card-title" Text="Status" />
+                        <Border Grid.Column="1" Classes="pill"
+                                Classes.ok="{Binding HwInfoStatusOk}"
+                                Classes.neutral="{Binding HwInfoStatusNeutral}">
+                            <TextBlock Text="{Binding HwInfoStatusText}" />
+                        </Border>
+                    </Grid>
+                    <TextBlock Classes="hint" Margin="0,6,0,0" TextWrapping="Wrap"
+                               Text="{Binding HwInfoDiagnostics}" />
+                </StackPanel>
+            </Border>
+
+            <Border Grid.Row="3" Classes="card" IsEnabled="{Binding HwInfoEnabled}">
+                <Grid RowDefinitions="Auto,*">
+                    <TextBlock Grid.Row="0" Classes="card-title" Text="Sensors (first 60)" />
+                    <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" Padding="0,0,16,0">
+                        <ItemsControl ItemsSource="{Binding HwInfoSensors}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="hwinfo:HwInfoSensor">
                                     <Grid ColumnDefinitions="*,Auto" Margin="0,2,0,2">
                                         <TextBlock Grid.Column="0" Text="{Binding Label}" />
                                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">


### PR DESCRIPTION
Add a HWiNFO sensor source mirroring the Argus Monitor integration: HwInfoService reads the Global\HWiNFO_SENS_SM2 shared memory, the HwInfo.Sensor dynamic-text command exposes readings to buttons, and a new HWiNFO settings page lists live values.

Integrations (Argus, Elgato, HWiNFO) are now gated behind per-feature master switches in LoupedeckConfig, defaulting to off so background polling and network discovery stay dormant until the user opts in. The switches start/stop the services at runtime and hide the related commands from the button command menus when disabled.

All flags default to false, so older config.json files load unchanged.