### PR TITLE
Add visual macro editor with user-defined macros

### DIFF
--- a/Commands/MacroCommands.cs
+++ b/Commands/MacroCommands.cs
@@ -1,5 +1,6 @@
 using LoupixDeck.Commands.Base;
 using LoupixDeck.Services;
+using LoupixDeck.Services.Macros;
 
 namespace LoupixDeck.Commands;
 
@@ -53,5 +54,37 @@ public class KeyCombinationCommand(IUInputKeyboard uInputKeyboard) : IExecutable
 
         uInputKeyboard.SendKeyCombination(keys);
         return Task.CompletedTask;
+    }
+}
+
+[Command(
+    "System.Macro",
+    "Macro",
+    "User Macros",
+    "({Name})",
+    ["Name"],
+    [typeof(string)],
+    Platform = CommandPlatform.All,
+    // Hidden from the generic group listing — UserMacroMenuContributor emits one
+    // menu entry per defined macro instead of a single "Macro" leaf.
+    Hidden = true)]
+public class MacroCommand(IMacroManager macroManager, MacroRunner macroRunner) : IExecutableCommand
+{
+    public Task Execute(string[] parameters)
+    {
+        if (parameters.Length != 1)
+        {
+            Console.WriteLine("Invalid Parametercount");
+            return Task.CompletedTask;
+        }
+
+        var macro = macroManager.Get(parameters[0]);
+        if (macro == null)
+        {
+            Console.Error.WriteLine($"[MacroCommand] Macro '{parameters[0]}' not found.");
+            return Task.CompletedTask;
+        }
+
+        return macroRunner.Run(macro);
     }
 }

--- a/Models/Converter/MacroStepJsonConverter.cs
+++ b/Models/Converter/MacroStepJsonConverter.cs
@@ -1,0 +1,79 @@
+using LoupixDeck.Models.Macros;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LoupixDeck.Models.Converter;
+
+/// <summary>
+/// Serializes <see cref="MacroStep"/> instances with a "StepType" discriminator
+/// (the <see cref="MacroStepType"/> enum name) instead of CLR type names, so the
+/// file format survives refactorings. Steps with an unknown discriminator (written
+/// by a newer app version) deserialize to null and are filtered out by the loader.
+/// </summary>
+public class MacroStepJsonConverter : JsonConverter
+{
+    private const string DiscriminatorProperty = "StepType";
+
+    // Plain serializer without this converter — used for the inner (per-property)
+    // round-trip so WriteJson/ReadJson don't recurse into themselves.
+    private static readonly JsonSerializer PlainSerializer = CreatePlainSerializer();
+
+    private static JsonSerializer CreatePlainSerializer()
+    {
+        var serializer = new JsonSerializer();
+        // Enum properties (mouse action/button) as names, not numbers — readable and
+        // safe against enum reordering.
+        serializer.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+        return serializer;
+    }
+
+    public override bool CanConvert(Type objectType) => typeof(MacroStep).IsAssignableFrom(objectType);
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value is not MacroStep step)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        var obj = JObject.FromObject(step, PlainSerializer);
+        obj.AddFirst(new JProperty(DiscriminatorProperty, step.StepType.ToString()));
+        obj.WriteTo(writer);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+        JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+            return null;
+
+        var obj = JObject.Load(reader);
+        var discriminator = obj[DiscriminatorProperty]?.Value<string>();
+
+        if (!Enum.TryParse<MacroStepType>(discriminator, ignoreCase: true, out var stepType))
+        {
+            Console.WriteLine($"[MacroStepJsonConverter] Unknown step type '{discriminator}' — skipping step.");
+            return null;
+        }
+
+        MacroStep step = stepType switch
+        {
+            MacroStepType.Text => new TextStep(),
+            MacroStepType.KeyCombination => new KeyCombinationStep(),
+            MacroStepType.Delay => new DelayStep(),
+            MacroStepType.KeyDown => new KeyDownStep(),
+            MacroStepType.KeyUp => new KeyUpStep(),
+            MacroStepType.Mouse => new MouseStep(),
+            MacroStepType.Command => new CommandStep(),
+            _ => null
+        };
+
+        if (step == null)
+            return null;
+
+        using var subReader = obj.CreateReader();
+        PlainSerializer.Populate(subReader, step);
+        return step;
+    }
+}

--- a/Models/Macros/Macro.cs
+++ b/Models/Macros/Macro.cs
@@ -1,0 +1,38 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace LoupixDeck.Models.Macros;
+
+/// <summary>
+/// A named, user-defined macro: an ordered list of steps executed sequentially
+/// by <c>System.Macro(Name)</c>. Persisted in macros.json (see <see cref="MacroSettings"/>).
+/// </summary>
+public class Macro : INotifyPropertyChanged
+{
+    private string _name = string.Empty;
+
+    /// <summary>
+    /// Unique macro name. Must not contain '(' ')' ',' or '&amp;' — those would break
+    /// the command parser when the macro is invoked as System.Macro(Name).
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (_name == value) return;
+            _name = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public ObservableCollection<MacroStep> Steps { get; set; } = [];
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Models/Macros/MacroSettings.cs
+++ b/Models/Macros/MacroSettings.cs
@@ -1,0 +1,15 @@
+namespace LoupixDeck.Models.Macros;
+
+/// <summary>
+/// Root document of macros.json. Kept separate from config.json so user macros
+/// survive independently of device configs. Schema changes should stay additive;
+/// unknown step types in newer files are skipped gracefully on load.
+/// </summary>
+public class MacroSettings
+{
+    public const int CurrentVersion = 1;
+
+    public int Version { get; set; } = CurrentVersion;
+
+    public List<Macro> Macros { get; set; } = [];
+}

--- a/Models/Macros/MacroStep.cs
+++ b/Models/Macros/MacroStep.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+
+namespace LoupixDeck.Models.Macros;
+
+/// <summary>
+/// Base class of a single macro step. Concrete steps carry the persisted data;
+/// the <see cref="Icon"/>/<see cref="TypeText"/>/<see cref="ValueText"/> properties
+/// are UI projections for the editor's step panels and are never serialized.
+/// Serialization is handled by <see cref="Converter.MacroStepJsonConverter"/>, which
+/// writes the <see cref="StepType"/> discriminator.
+/// </summary>
+public abstract class MacroStep : INotifyPropertyChanged
+{
+    /// <summary>Discriminator identifying the concrete step type.</summary>
+    [JsonIgnore]
+    public abstract MacroStepType StepType { get; }
+
+    /// <summary>MDI font glyph shown in the step panel (use with the MdiFont resource).</summary>
+    [JsonIgnore]
+    public abstract string Icon { get; }
+
+    /// <summary>Human-readable step type label.</summary>
+    [JsonIgnore]
+    public abstract string TypeText { get; }
+
+    /// <summary>Short summary of the step's value (text, key combo, delay, ...).</summary>
+    [JsonIgnore]
+    public abstract string ValueText { get; }
+
+    private bool _isEditing;
+
+    /// <summary>True while the step panel's inline editor is expanded (editor UI state only).</summary>
+    [JsonIgnore]
+    public bool IsEditing
+    {
+        get => _isEditing;
+        set
+        {
+            if (_isEditing == value) return;
+            _isEditing = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private bool _isDragging;
+
+    /// <summary>True while the step panel is being dragged for reordering (editor UI state only).</summary>
+    [JsonIgnore]
+    public bool IsDragging
+    {
+        get => _isDragging;
+        set
+        {
+            if (_isDragging == value) return;
+            _isDragging = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    /// <summary>
+    /// Raises change notifications for a data property AND the derived <see cref="ValueText"/>,
+    /// so the panel summary updates live while the user edits inline.
+    /// </summary>
+    protected void OnValueChanged([CallerMemberName] string propertyName = null)
+    {
+        OnPropertyChanged(propertyName);
+        OnPropertyChanged(nameof(ValueText));
+    }
+
+    /// <summary>Renders an MDI codepoint as a glyph string.</summary>
+    protected static string Glyph(int codepoint) => char.ConvertFromUtf32(codepoint);
+}

--- a/Models/Macros/MacroStepType.cs
+++ b/Models/Macros/MacroStepType.cs
@@ -1,0 +1,36 @@
+namespace LoupixDeck.Models.Macros;
+
+/// <summary>
+/// Discriminator for the persisted macro step types. The enum NAME (not the
+/// numeric value) is written to macros.json, so renaming a member is a breaking
+/// change while appending new members is always safe.
+/// </summary>
+public enum MacroStepType
+{
+    Text,
+    KeyCombination,
+    Delay,
+    KeyDown,
+    KeyUp,
+    Mouse,
+    Command
+}
+
+/// <summary>What a <see cref="MouseStep"/> does.</summary>
+public enum MouseStepAction
+{
+    Click,
+    Down,
+    Up,
+    MoveRelative,
+    MoveAbsolute,
+    Scroll
+}
+
+/// <summary>Mouse button used by click/down/up mouse steps.</summary>
+public enum MouseButton
+{
+    Left,
+    Right,
+    Middle
+}

--- a/Models/Macros/MacroSteps.cs
+++ b/Models/Macros/MacroSteps.cs
@@ -1,0 +1,239 @@
+namespace LoupixDeck.Models.Macros;
+
+/// <summary>Types a text string via the virtual keyboard.</summary>
+public class TextStep : MacroStep
+{
+    private string _text = string.Empty;
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text == value) return;
+            _text = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.Text;
+    public override string Icon => Glyph(0xF030C); // mdi-keyboard
+    public override string TypeText => "Type Text";
+    public override string ValueText => Text ?? string.Empty;
+}
+
+/// <summary>Presses a key combination, e.g. "Ctrl+Shift+Esc".</summary>
+public class KeyCombinationStep : MacroStep
+{
+    private string _keys = string.Empty;
+
+    /// <summary>Key names joined with '+', same syntax as System.KeyCombination.</summary>
+    public string Keys
+    {
+        get => _keys;
+        set
+        {
+            if (_keys == value) return;
+            _keys = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.KeyCombination;
+    public override string Icon => Glyph(0xF0317); // mdi-keyboard-variant
+    public override string TypeText => "Key Combination";
+    public override string ValueText => Keys ?? string.Empty;
+}
+
+/// <summary>Waits for a fixed amount of time before the next step.</summary>
+public class DelayStep : MacroStep
+{
+    private int _milliseconds = 100;
+
+    public int Milliseconds
+    {
+        get => _milliseconds;
+        set
+        {
+            if (_milliseconds == value) return;
+            _milliseconds = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.Delay;
+    public override string Icon => Glyph(0xF051F); // mdi-timer-sand
+    public override string TypeText => "Delay";
+    public override string ValueText => $"{Milliseconds} ms";
+}
+
+/// <summary>Presses (and holds) a single key without releasing it.</summary>
+public class KeyDownStep : MacroStep
+{
+    private string _key = string.Empty;
+
+    public string Key
+    {
+        get => _key;
+        set
+        {
+            if (_key == value) return;
+            _key = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.KeyDown;
+    public override string Icon => Glyph(0xF013C); // mdi-chevron-double-down
+    public override string TypeText => "Key Down";
+    public override string ValueText => Key ?? string.Empty;
+}
+
+/// <summary>Releases a key previously held down by a <see cref="KeyDownStep"/>.</summary>
+public class KeyUpStep : MacroStep
+{
+    private string _key = string.Empty;
+
+    public string Key
+    {
+        get => _key;
+        set
+        {
+            if (_key == value) return;
+            _key = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.KeyUp;
+    public override string Icon => Glyph(0xF013F); // mdi-chevron-double-up
+    public override string TypeText => "Key Up";
+    public override string ValueText => Key ?? string.Empty;
+}
+
+/// <summary>Performs a mouse action (click, button down/up, move, scroll).</summary>
+public class MouseStep : MacroStep
+{
+    /// <summary>All selectable actions/buttons — bound by the editor's ComboBoxes.</summary>
+    public static MouseStepAction[] AllActions { get; } = Enum.GetValues<MouseStepAction>();
+
+    public static MouseButton[] AllButtons { get; } = Enum.GetValues<MouseButton>();
+
+    private MouseStepAction _action = MouseStepAction.Click;
+    private MouseButton _button = MouseButton.Left;
+    private int _x;
+    private int _y;
+    private int _amount = 1;
+
+    public MouseStepAction Action
+    {
+        get => _action;
+        set
+        {
+            if (_action == value) return;
+            _action = value;
+            OnValueChanged();
+            OnPropertyChanged(nameof(ShowsButton));
+            OnPropertyChanged(nameof(ShowsCoordinates));
+            OnPropertyChanged(nameof(ShowsAmount));
+            OnPropertyChanged(nameof(ShowsAbsoluteHint));
+        }
+    }
+
+    /// <summary>Editor visibility helpers — which fields apply to the selected action.</summary>
+    [Newtonsoft.Json.JsonIgnore]
+    public bool ShowsButton => Action is MouseStepAction.Click or MouseStepAction.Down or MouseStepAction.Up;
+
+    [Newtonsoft.Json.JsonIgnore]
+    public bool ShowsCoordinates => Action is MouseStepAction.MoveRelative or MouseStepAction.MoveAbsolute;
+
+    [Newtonsoft.Json.JsonIgnore]
+    public bool ShowsAmount => Action == MouseStepAction.Scroll;
+
+    [Newtonsoft.Json.JsonIgnore]
+    public bool ShowsAbsoluteHint => Action == MouseStepAction.MoveAbsolute;
+
+    public MouseButton Button
+    {
+        get => _button;
+        set
+        {
+            if (_button == value) return;
+            _button = value;
+            OnValueChanged();
+        }
+    }
+
+    /// <summary>X coordinate: relative delta for MoveRelative, screen pixel for MoveAbsolute.</summary>
+    public int X
+    {
+        get => _x;
+        set
+        {
+            if (_x == value) return;
+            _x = value;
+            OnValueChanged();
+        }
+    }
+
+    /// <summary>Y coordinate: relative delta for MoveRelative, screen pixel for MoveAbsolute.</summary>
+    public int Y
+    {
+        get => _y;
+        set
+        {
+            if (_y == value) return;
+            _y = value;
+            OnValueChanged();
+        }
+    }
+
+    /// <summary>Scroll amount in wheel detents (positive = up, negative = down).</summary>
+    public int Amount
+    {
+        get => _amount;
+        set
+        {
+            if (_amount == value) return;
+            _amount = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.Mouse;
+    public override string Icon => Glyph(0xF037D); // mdi-mouse
+    public override string TypeText => "Mouse";
+
+    public override string ValueText => Action switch
+    {
+        MouseStepAction.Click => $"{Button} Click",
+        MouseStepAction.Down => $"{Button} Down",
+        MouseStepAction.Up => $"{Button} Up",
+        MouseStepAction.MoveRelative => $"Move by {X}, {Y}",
+        MouseStepAction.MoveAbsolute => $"Move to {X}, {Y}",
+        MouseStepAction.Scroll => $"Scroll {Amount}",
+        _ => string.Empty
+    };
+}
+
+/// <summary>Runs an arbitrary LoupixDeck command string or shell command.</summary>
+public class CommandStep : MacroStep
+{
+    private string _commandString = string.Empty;
+
+    public string CommandString
+    {
+        get => _commandString;
+        set
+        {
+            if (_commandString == value) return;
+            _commandString = value;
+            OnValueChanged();
+        }
+    }
+
+    public override MacroStepType StepType => MacroStepType.Command;
+    public override string Icon => Glyph(0xF018D); // mdi-console
+    public override string TypeText => "Command";
+    public override string ValueText => CommandString ?? string.Empty;
+}

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using LoupixDeck.Registry;
 using LoupixDeck.Services;
 using LoupixDeck.Services.Commands;
 using LoupixDeck.Services.FolderNavigation;
+using LoupixDeck.Services.Macros;
+using LoupixDeck.Services.Mouse;
 using LoupixDeck.Services.Plugins;
 using LoupixDeck.Services.SystemPower;
 using LoupixDeck.Utils;
@@ -71,8 +73,13 @@ public static class ServiceCollectionExtensions
         // The command-selection menu is assembled generically from these
         // contributors instead of the former per-ViewModel hard-coded logic.
         collection.AddSingleton<IMenuContributor, CommandGroupMenuContributor>();
+        collection.AddSingleton<IMenuContributor, UserMacroMenuContributor>();
         collection.AddSingleton<IPluginMenuSource, PluginMenuContributor>();
         collection.AddSingleton<IMenuTreeBuilder, MenuTreeBuilder>();
+
+        // User-defined macros: in-memory store (macros.json) + sequential step executor.
+        collection.AddSingleton<IMacroManager, MacroManager>();
+        collection.AddSingleton<MacroRunner>();
 
         // UInputKeyboard is only available on Linux
         if (OperatingSystem.IsLinux())
@@ -80,6 +87,9 @@ public static class ServiceCollectionExtensions
             collection.AddSingleton<IUInputKeyboard, UInputKeyboard>();
             // No Interception on Linux — register a stand-in so SettingsViewModel still resolves.
             collection.AddSingleton<IInterceptionService, NoOpInterceptionService>();
+
+            // Virtual mouse for macro mouse steps (uinput-backed).
+            collection.AddSingleton<IVirtualMouse, UInputMouse>();
         }
         else
         {
@@ -91,6 +101,9 @@ public static class ServiceCollectionExtensions
 
             // Manages downloading/installing/uninstalling the Interception driver (settings page).
             collection.AddSingleton<IInterceptionService, InterceptionService>();
+
+            // Virtual mouse for macro mouse steps (SendInput-backed; Interception mouse is not used).
+            collection.AddSingleton<IVirtualMouse, WindowsVirtualMouse>();
         }
 
         collection.AddSingleton<IDBusController, DBusController>();
@@ -169,7 +182,10 @@ public static class ServiceCollectionExtensions
 
         collection.AddTransient<Settings>();
         collection.AddTransient<SettingsViewModel>();
-        
+
+        collection.AddTransient<MacroEditor>();
+        collection.AddTransient<MacroEditorViewModel>();
+
         collection.AddTransient<About>();
         collection.AddTransient<AboutViewModel>();
         
@@ -187,7 +203,11 @@ public static class ServiceCollectionExtensions
         dialogService.Register<TouchPageWallpaperSettingsViewModel, TouchPageWallpaperSettings>();
         dialogService.Register<PageCommandsSettingsViewModel, PageCommandsSettings>();
         dialogService.Register<SettingsViewModel, Settings>();
+        dialogService.Register<MacroEditorViewModel, MacroEditor>();
         dialogService.Register<AboutViewModel, About>();
+
+        // Load user macros once — execution and menus read from memory afterwards.
+        services.GetRequiredService<IMacroManager>().Load();
 
         // Let the (static) bitmap renderer resolve image-layer assets via DI.
         var assetService = services.GetRequiredService<IAssetService>();

--- a/Services/Commands/CoreCommandProvider.cs
+++ b/Services/Commands/CoreCommandProvider.cs
@@ -92,6 +92,9 @@ public class CoreCommandProvider : ICommandProvider
             "Pages" => ButtonTargets.All,
             "Device Control" => ButtonTargets.All,
             "Macros" => ButtonTargets.TouchButton,
+            // User-defined macros (System.Macro) are generic input automation —
+            // assignable to every button type.
+            "User Macros" => ButtonTargets.All,
             "Dynamic Text" => ButtonTargets.TouchButton,
             // "Button Control" and anything unmapped is not menu-assignable.
             _ => ButtonTargets.None

--- a/Services/Commands/MenuTreeBuilder.cs
+++ b/Services/Commands/MenuTreeBuilder.cs
@@ -14,7 +14,7 @@ public class MenuTreeBuilder : IMenuTreeBuilder
     /// </summary>
     private static readonly string[] CoreGroupOrder =
     {
-        "Pages", "Device Control", "Macros", "Dynamic Text", "Audio"
+        "Pages", "Device Control", "Macros", "User Macros", "Dynamic Text", "Audio"
     };
 
     /// <summary>How long a single plugin may take before its menu is skipped.</summary>

--- a/Services/InterceptionKeyboard.cs
+++ b/Services/InterceptionKeyboard.cs
@@ -22,9 +22,10 @@ namespace LoupixDeck.Services
         // INTERCEPTION_KEYBOARD(0): keyboards are devices 1..10, mice 11..20.
         private const int KeyboardDevice = 1;
 
-        // InterceptionKeyState flags.
-        private const ushort KeyDown = 0x00;
-        private const ushort KeyUp = 0x01;
+        // InterceptionKeyState flags. (Named State* to avoid colliding with the
+        // IUInputKeyboard.KeyDown/KeyUp methods.)
+        private const ushort StateKeyDown = 0x00;
+        private const ushort StateKeyUp = 0x01;
         private const ushort KeyE0 = 0x02;
 
         // Left Shift make code (PS/2 set 1) — used to type shifted characters in SendText.
@@ -175,6 +176,31 @@ namespace LoupixDeck.Services
             }
         }
 
+        public void KeyDown(string keyName)
+        {
+            SendSingle(keyName, up: false);
+        }
+
+        public void KeyUp(string keyName)
+        {
+            SendSingle(keyName, up: true);
+        }
+
+        private void SendSingle(string keyName, bool up)
+        {
+            if (!KeyNames.TryGetInterception(keyName, out var scanCode, out var e0))
+            {
+                Console.Error.WriteLine($"[InterceptionKeyboard] Unknown key name: '{keyName}'");
+                return;
+            }
+
+            lock (_lock)
+            {
+                if (!EnsureContext()) return;
+                SendStrokeVerified((ushort)scanCode, e0, up);
+            }
+        }
+
         public void Dispose()
         {
             lock (_lock)
@@ -310,7 +336,7 @@ namespace LoupixDeck.Services
 
         private static InterceptionStroke Stroke(ushort code, bool e0, bool up)
         {
-            ushort state = up ? KeyUp : KeyDown;
+            ushort state = up ? StateKeyUp : StateKeyDown;
             if (e0) state |= KeyE0;
             return new InterceptionStroke { Code = code, State = state, Information = 0 };
         }

--- a/Services/Macros/IMacroManager.cs
+++ b/Services/Macros/IMacroManager.cs
@@ -1,0 +1,35 @@
+using LoupixDeck.Models.Macros;
+
+namespace LoupixDeck.Services.Macros;
+
+/// <summary>
+/// In-memory store of the user-defined macros backed by macros.json. Loaded once
+/// at startup; all reads (execution, menus) are served from memory.
+/// </summary>
+public interface IMacroManager
+{
+    /// <summary>All currently defined macros.</summary>
+    IReadOnlyList<Macro> Macros { get; }
+
+    /// <summary>Loads macros.json into memory. Called once during startup.</summary>
+    void Load();
+
+    /// <summary>Case-insensitive lookup by macro name; null when not found.</summary>
+    Macro Get(string name);
+
+    /// <summary>Replaces the whole macro set (editor save) and persists it.</summary>
+    void ReplaceAll(IEnumerable<Macro> macros);
+
+    /// <summary>Persists the current in-memory macros to macros.json.</summary>
+    void Save();
+
+    /// <summary>
+    /// True when <paramref name="name"/> is a usable macro name: non-empty, free of
+    /// command-parser characters ( ) , &amp; and unique among all macros except
+    /// <paramref name="ignore"/>.
+    /// </summary>
+    bool IsNameValid(string name, Macro ignore = null);
+
+    /// <summary>Raised after the macro set changed (editor save).</summary>
+    event EventHandler MacrosChanged;
+}

--- a/Services/Macros/MacroManager.cs
+++ b/Services/Macros/MacroManager.cs
@@ -1,0 +1,180 @@
+using LoupixDeck.Models.Converter;
+using LoupixDeck.Models.Macros;
+using LoupixDeck.Utils;
+using Newtonsoft.Json;
+
+namespace LoupixDeck.Services.Macros;
+
+/// <inheritdoc cref="IMacroManager"/>
+public class MacroManager : IMacroManager
+{
+    private const string FileName = "macros.json";
+
+    // Characters that would break CommandService's "Name(args)" / "a && b" parsing
+    // if they appeared in a macro name.
+    private static readonly char[] ForbiddenNameChars = ['(', ')', ',', '&'];
+
+    // Own serializer settings (not ConfigService's) so the step converter never
+    // leaks into config.json serialization.
+    private static readonly JsonSerializerSettings SerializerSettings = new()
+    {
+        Formatting = Formatting.Indented,
+        Converters = { new MacroStepJsonConverter() }
+    };
+
+    private readonly object _lock = new();
+
+    private List<Macro> _macros = [];
+    private Dictionary<string, Macro> _byName = new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlyList<Macro> Macros
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _macros.ToList();
+            }
+        }
+    }
+
+    public event EventHandler MacrosChanged;
+
+    public void Load()
+    {
+        var path = FileDialogHelper.GetConfigPath(FileName);
+
+        MacroSettings settings = null;
+        try
+        {
+            if (File.Exists(path))
+            {
+                var json = File.ReadAllText(path);
+                settings = JsonConvert.DeserializeObject<MacroSettings>(json, SerializerSettings);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[MacroManager] Failed to load {path}: {ex.Message}");
+            BackupCorruptedFile(path);
+        }
+
+        settings ??= new MacroSettings();
+
+        lock (_lock)
+        {
+            // Steps with unknown discriminators deserialize to null — drop them.
+            _macros = settings.Macros?
+                .Where(m => m != null && !string.IsNullOrWhiteSpace(m.Name))
+                .ToList() ?? [];
+
+            foreach (var macro in _macros)
+            {
+                var steps = macro.Steps?.Where(s => s != null).ToList() ?? [];
+                macro.Steps = new System.Collections.ObjectModel.ObservableCollection<MacroStep>(steps);
+            }
+
+            RebuildIndex();
+        }
+    }
+
+    public Macro Get(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        lock (_lock)
+        {
+            return _byName.GetValueOrDefault(name.Trim());
+        }
+    }
+
+    public void ReplaceAll(IEnumerable<Macro> macros)
+    {
+        lock (_lock)
+        {
+            _macros = macros?
+                .Where(m => m != null && !string.IsNullOrWhiteSpace(m.Name))
+                .ToList() ?? [];
+            RebuildIndex();
+        }
+
+        Save();
+    }
+
+    public void Save()
+    {
+        var path = FileDialogHelper.GetConfigPath(FileName);
+
+        MacroSettings settings;
+        lock (_lock)
+        {
+            settings = new MacroSettings { Macros = _macros.ToList() };
+        }
+
+        try
+        {
+            var json = JsonConvert.SerializeObject(settings, SerializerSettings);
+
+            // Atomic write: temp file first, then move into place (same pattern as ConfigService).
+            var tempPath = path + ".tmp";
+            File.WriteAllText(tempPath, json);
+            if (File.Exists(path))
+                File.Delete(path);
+            File.Move(tempPath, path);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[MacroManager] Failed to save {path}: {ex.Message}");
+        }
+
+        MacrosChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Character-level name check (non-empty, no command-parser characters). Used by the
+    /// editor for working copies that are not part of the manager's in-memory set.
+    /// </summary>
+    public static bool HasValidNameCharacters(string name)
+    {
+        return !string.IsNullOrWhiteSpace(name) && name.IndexOfAny(ForbiddenNameChars) < 0;
+    }
+
+    public bool IsNameValid(string name, Macro ignore = null)
+    {
+        if (!HasValidNameCharacters(name))
+            return false;
+
+        lock (_lock)
+        {
+            var existing = _byName.GetValueOrDefault(name.Trim());
+            return existing == null || ReferenceEquals(existing, ignore);
+        }
+    }
+
+    // Caller must hold _lock.
+    private void RebuildIndex()
+    {
+        _byName = new Dictionary<string, Macro>(StringComparer.OrdinalIgnoreCase);
+        foreach (var macro in _macros)
+        {
+            _byName.TryAdd(macro.Name.Trim(), macro);
+        }
+    }
+
+    private static void BackupCorruptedFile(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return;
+
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            File.Move(path, $"{path}.corrupted.{timestamp}.bak");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[MacroManager] Failed to backup corrupted file: {ex.Message}");
+        }
+    }
+}

--- a/Services/Macros/MacroRunner.cs
+++ b/Services/Macros/MacroRunner.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using LoupixDeck.Models.Macros;
+using LoupixDeck.PluginSdk;
+using LoupixDeck.Services.Mouse;
+
+namespace LoupixDeck.Services.Macros;
+
+/// <summary>
+/// Executes the steps of a user-defined macro sequentially. Each step is wrapped in
+/// its own try/catch so a faulty step (unknown key, failing command) does not abort
+/// the rest of the macro.
+/// </summary>
+public class MacroRunner
+{
+    private readonly IUInputKeyboard _keyboard;
+    private readonly IVirtualMouse _mouse;
+    private readonly ICommandService _commandService;
+
+    public MacroRunner(IUInputKeyboard keyboard, IVirtualMouse mouse, ICommandService commandService)
+    {
+        _keyboard = keyboard;
+        _mouse = mouse;
+        _commandService = commandService;
+    }
+
+    public async Task Run(Macro macro)
+    {
+        if (macro == null)
+        {
+            Console.Error.WriteLine("[MacroRunner] Macro not found.");
+            return;
+        }
+
+        foreach (var step in macro.Steps)
+        {
+            if (step == null) continue;
+
+            try
+            {
+                await ExecuteStep(step);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[MacroRunner] Step '{step.TypeText}' in macro '{macro.Name}' failed: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task ExecuteStep(MacroStep step)
+    {
+        switch (step)
+        {
+            case TextStep text:
+                if (!string.IsNullOrEmpty(text.Text))
+                    _keyboard.SendText(text.Text);
+                break;
+
+            case KeyCombinationStep combo:
+                var keys = (combo.Keys ?? string.Empty)
+                    .Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (keys.Length > 0)
+                    _keyboard.SendKeyCombination(keys);
+                break;
+
+            case DelayStep delay:
+                await Delay(delay.Milliseconds);
+                break;
+
+            case KeyDownStep keyDown:
+                if (!string.IsNullOrWhiteSpace(keyDown.Key))
+                    _keyboard.KeyDown(keyDown.Key);
+                break;
+
+            case KeyUpStep keyUp:
+                if (!string.IsNullOrWhiteSpace(keyUp.Key))
+                    _keyboard.KeyUp(keyUp.Key);
+                break;
+
+            case MouseStep mouse:
+                ExecuteMouseStep(mouse);
+                break;
+
+            case CommandStep command:
+                if (!string.IsNullOrWhiteSpace(command.CommandString))
+                    await _commandService.ExecuteCommand(command.CommandString, ButtonTargets.None);
+                break;
+        }
+    }
+
+    private void ExecuteMouseStep(MouseStep step)
+    {
+        switch (step.Action)
+        {
+            case MouseStepAction.Click:
+                _mouse.Click(step.Button);
+                break;
+            case MouseStepAction.Down:
+                _mouse.ButtonDown(step.Button);
+                break;
+            case MouseStepAction.Up:
+                _mouse.ButtonUp(step.Button);
+                break;
+            case MouseStepAction.MoveRelative:
+                _mouse.MoveRelative(step.X, step.Y);
+                break;
+            case MouseStepAction.MoveAbsolute:
+                _mouse.MoveAbsolute(step.X, step.Y);
+                break;
+            case MouseStepAction.Scroll:
+                _mouse.Scroll(step.Amount);
+                break;
+        }
+    }
+
+    // Coarse Task.Delay for the bulk, short spin for the tail — Task.Delay alone has
+    // ~15 ms granularity on Windows (same pattern as DeviceControlCommands.WaitUntilMs).
+    private static async Task Delay(int milliseconds)
+    {
+        if (milliseconds <= 0)
+            return;
+
+        var sw = Stopwatch.StartNew();
+        while (true)
+        {
+            var remain = milliseconds - sw.Elapsed.TotalMilliseconds;
+            if (remain <= 0) return;
+            if (remain > 3) await Task.Delay(1);
+            else Thread.SpinWait(200);
+        }
+    }
+}

--- a/Services/Macros/UserMacroMenuContributor.cs
+++ b/Services/Macros/UserMacroMenuContributor.cs
@@ -1,0 +1,39 @@
+using LoupixDeck.Models;
+using LoupixDeck.PluginSdk;
+using LoupixDeck.Services.Commands;
+// Both the app and the plugin SDK define IMenuContributor — this contributor implements the app-side one.
+using IMenuContributor = LoupixDeck.Services.Commands.IMenuContributor;
+
+namespace LoupixDeck.Services.Macros;
+
+/// <summary>
+/// Lists every user-defined macro as a leaf in a dedicated "User Macros" menu group.
+/// Selecting an entry inserts <c>System.Macro(MacroName)</c> into the button command
+/// (the CommandBuilder substitutes the entry's Name as the first parameter).
+/// </summary>
+public class UserMacroMenuContributor : IMenuContributor
+{
+    public const string GroupName = "User Macros";
+
+    private readonly IMacroManager _macroManager;
+
+    public UserMacroMenuContributor(IMacroManager macroManager)
+    {
+        _macroManager = macroManager;
+    }
+
+    public Task<IReadOnlyList<MenuEntry>> Contribute(ButtonTargets target)
+    {
+        var macros = _macroManager.Macros;
+        if (macros.Count == 0)
+            return Task.FromResult<IReadOnlyList<MenuEntry>>([]);
+
+        var group = new MenuEntry(GroupName, string.Empty);
+        foreach (var macro in macros.OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            group.Children.Add(new MenuEntry(macro.Name, "System.Macro"));
+        }
+
+        return Task.FromResult<IReadOnlyList<MenuEntry>>([group]);
+    }
+}

--- a/Services/Mouse/IVirtualMouse.cs
+++ b/Services/Mouse/IVirtualMouse.cs
@@ -1,0 +1,35 @@
+using LoupixDeck.Models.Macros;
+
+namespace LoupixDeck.Services.Mouse;
+
+/// <summary>
+/// Virtual mouse used by macro mouse steps. Windows: SendInput; Linux: uinput.
+/// Kept separate from <see cref="IUInputKeyboard"/> so the keyboard backends
+/// (including Interception) stay untouched.
+/// </summary>
+public interface IVirtualMouse : IDisposable
+{
+    /// <summary>False when the backend could not be initialized (all calls become no-ops).</summary>
+    bool Connected { get; }
+
+    /// <summary>Presses and releases a mouse button.</summary>
+    void Click(MouseButton button);
+
+    /// <summary>Presses a mouse button and keeps it held.</summary>
+    void ButtonDown(MouseButton button);
+
+    /// <summary>Releases a mouse button previously held by <see cref="ButtonDown"/>.</summary>
+    void ButtonUp(MouseButton button);
+
+    /// <summary>Moves the cursor by a relative delta in device units (≈ pixels).</summary>
+    void MoveRelative(int dx, int dy);
+
+    /// <summary>
+    /// Moves the cursor to an absolute screen position in pixels.
+    /// Not supported on Linux (no-op with a log message).
+    /// </summary>
+    void MoveAbsolute(int x, int y);
+
+    /// <summary>Scrolls the wheel by the given number of detents (positive = up).</summary>
+    void Scroll(int amount);
+}

--- a/Services/Mouse/UInputMouse.cs
+++ b/Services/Mouse/UInputMouse.cs
@@ -1,0 +1,253 @@
+using System.Runtime.InteropServices;
+using LoupixDeck.Models.Macros;
+
+namespace LoupixDeck.Services.Mouse;
+
+/// <summary>
+/// Linux implementation backed by a uinput virtual mouse device (relative axes +
+/// buttons + wheel). Same P/Invoke pattern as <see cref="UInputKeyboard"/>.
+/// Absolute positioning is not supported (would require an EV_ABS device) — see
+/// <see cref="MoveAbsolute"/>.
+/// </summary>
+public class UInputMouse : IVirtualMouse
+{
+    private const string UINPUT_PATH = "/dev/uinput";
+
+    private const int O_WRONLY = 0x0001;
+    private const int O_NONBLOCK = 0x0800;
+
+    private const int UI_SET_EVBIT = 0x40045564;
+    private const int UI_SET_KEYBIT = 0x40045565;
+    private const int UI_SET_RELBIT = 0x40045566;
+
+    private const int UI_DEV_CREATE = 0x5501;
+    private const int UI_DEV_DESTROY = 0x5502;
+
+    private const int EV_SYN = 0x00;
+    private const int EV_KEY = 0x01;
+    private const int EV_REL = 0x02;
+
+    private const int SYN_REPORT = 0;
+
+    private const int BTN_LEFT = 0x110;
+    private const int BTN_RIGHT = 0x111;
+    private const int BTN_MIDDLE = 0x112;
+
+    private const int REL_X = 0x00;
+    private const int REL_Y = 0x01;
+    private const int REL_WHEEL = 0x08;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct InputEvent
+    {
+        public TimeVal time;
+        public ushort type;
+        public ushort code;
+        public int value;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TimeVal
+    {
+        public long tv_sec;
+        public long tv_usec;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UinputUserDev
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
+        public string name;
+        public ushort id_bustype;
+        public ushort id_vendor;
+        public ushort id_product;
+        public ushort id_version;
+        public int ff_effects_max;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64)]
+        public int[] absmax;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64)]
+        public int[] absmin;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64)]
+        public int[] absfuzz;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 64)]
+        public int[] absflat;
+    }
+
+    private struct SsizeT(IntPtr value)
+    {
+        public IntPtr Value = value;
+    }
+
+    private struct SizeT(int v)
+    {
+        public IntPtr Value = v;
+    }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int open(string pathname, int flags);
+
+    [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+    private static extern int ioctl(int fd, int request, int value);
+
+    [DllImport("libc", EntryPoint = "write", SetLastError = true)]
+    private static extern SsizeT write(int fd, IntPtr buffer, SizeT count);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int close(int fd);
+
+    private int _fileDescriptor;
+    private IntPtr _devPtr;
+    private bool _disposed;
+
+    public bool Connected { get; private set; }
+
+    public UInputMouse()
+    {
+        try
+        {
+            _fileDescriptor = open(UINPUT_PATH, O_WRONLY | O_NONBLOCK);
+        }
+        catch (Exception)
+        {
+            Connected = false;
+            return;
+        }
+
+        if (_fileDescriptor < 0)
+        {
+            // Same policy as UInputKeyboard: no exception, just report unavailable.
+            Connected = false;
+            return;
+        }
+
+        // Buttons
+        ioctl(_fileDescriptor, UI_SET_EVBIT, EV_KEY);
+        ioctl(_fileDescriptor, UI_SET_KEYBIT, BTN_LEFT);
+        ioctl(_fileDescriptor, UI_SET_KEYBIT, BTN_RIGHT);
+        ioctl(_fileDescriptor, UI_SET_KEYBIT, BTN_MIDDLE);
+
+        // Relative axes + wheel
+        ioctl(_fileDescriptor, UI_SET_EVBIT, EV_REL);
+        ioctl(_fileDescriptor, UI_SET_RELBIT, REL_X);
+        ioctl(_fileDescriptor, UI_SET_RELBIT, REL_Y);
+        ioctl(_fileDescriptor, UI_SET_RELBIT, REL_WHEEL);
+
+        var dev = new UinputUserDev
+        {
+            name = "LoupixVirtualMouse",
+            id_bustype = 0,
+            id_vendor = 0x1234,
+            id_product = 0x5679,
+            id_version = 1,
+            absmax = new int[64],
+            absmin = new int[64],
+            absfuzz = new int[64],
+            absflat = new int[64]
+        };
+
+        _devPtr = Marshal.AllocHGlobal(Marshal.SizeOf(dev));
+        Marshal.StructureToPtr(dev, _devPtr, false);
+
+        write(_fileDescriptor, _devPtr, new SizeT(Marshal.SizeOf(dev)));
+        ioctl(_fileDescriptor, UI_DEV_CREATE, 0);
+
+        Connected = true;
+    }
+
+    public void Click(MouseButton button)
+    {
+        if (!Connected) return;
+
+        var code = ButtonCode(button);
+        SendEvent(EV_KEY, code, 1);
+        SendEvent(EV_KEY, code, 0);
+    }
+
+    public void ButtonDown(MouseButton button)
+    {
+        if (!Connected) return;
+
+        SendEvent(EV_KEY, ButtonCode(button), 1);
+    }
+
+    public void ButtonUp(MouseButton button)
+    {
+        if (!Connected) return;
+
+        SendEvent(EV_KEY, ButtonCode(button), 0);
+    }
+
+    public void MoveRelative(int dx, int dy)
+    {
+        if (!Connected) return;
+
+        SendInputEvent(EV_REL, REL_X, dx);
+        SendInputEvent(EV_REL, REL_Y, dy);
+        SendInputEvent(EV_SYN, SYN_REPORT, 0);
+    }
+
+    public void MoveAbsolute(int x, int y)
+    {
+        // Would require an EV_ABS uinput device with ABS_X/ABS_Y absinfo — out of scope for v1.
+        Console.Error.WriteLine("[UInputMouse] MoveAbsolute is not supported on Linux.");
+    }
+
+    public void Scroll(int amount)
+    {
+        if (!Connected) return;
+
+        SendEvent(EV_REL, REL_WHEEL, amount);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        if (Connected)
+        {
+            ioctl(_fileDescriptor, UI_DEV_DESTROY, 0);
+            close(_fileDescriptor);
+            _fileDescriptor = -1;
+        }
+
+        if (_devPtr != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(_devPtr);
+            _devPtr = IntPtr.Zero;
+        }
+
+        _disposed = true;
+    }
+
+    private static int ButtonCode(MouseButton button) => button switch
+    {
+        MouseButton.Right => BTN_RIGHT,
+        MouseButton.Middle => BTN_MIDDLE,
+        _ => BTN_LEFT
+    };
+
+    // Sends one event followed by a SYN report.
+    private void SendEvent(int type, int code, int value)
+    {
+        SendInputEvent(type, code, value);
+        SendInputEvent(EV_SYN, SYN_REPORT, 0);
+    }
+
+    private void SendInputEvent(int type, int code, int value)
+    {
+        var inputEvent = new InputEvent
+        {
+            type = (ushort)type,
+            code = (ushort)code,
+            value = value
+        };
+
+        var size = Marshal.SizeOf(inputEvent);
+        var ptr = Marshal.AllocHGlobal(size);
+        Marshal.StructureToPtr(inputEvent, ptr, false);
+
+        write(_fileDescriptor, ptr, new SizeT(size));
+
+        Marshal.FreeHGlobal(ptr);
+    }
+}

--- a/Services/Mouse/WindowsVirtualMouse.cs
+++ b/Services/Mouse/WindowsVirtualMouse.cs
@@ -1,0 +1,166 @@
+using System.Runtime.InteropServices;
+using LoupixDeck.Models.Macros;
+
+namespace LoupixDeck.Services.Mouse;
+
+/// <summary>
+/// Windows implementation backed by the Win32 <c>SendInput</c> API (user32.dll).
+/// Injected mouse events enter the session input stream like a real mouse. Note:
+/// they carry the injected flag, so raw-input apps may ignore them (same limit as
+/// <see cref="WindowsUInputKeyboard"/>). Interception is intentionally not used
+/// for mouse input.
+/// </summary>
+public class WindowsVirtualMouse : IVirtualMouse
+{
+    private const int INPUT_MOUSE = 0;
+
+    private const uint MOUSEEVENTF_MOVE = 0x0001;
+    private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    private const uint MOUSEEVENTF_LEFTUP = 0x0004;
+    private const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+    private const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+    private const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020;
+    private const uint MOUSEEVENTF_MIDDLEUP = 0x0040;
+    private const uint MOUSEEVENTF_WHEEL = 0x0800;
+    private const uint MOUSEEVENTF_VIRTUALDESK = 0x4000;
+    private const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
+
+    private const int WHEEL_DELTA = 120;
+
+    // Virtual screen metrics (multi-monitor desktop bounding box).
+    private const int SM_XVIRTUALSCREEN = 76;
+    private const int SM_YVIRTUALSCREEN = 77;
+    private const int SM_CXVIRTUALSCREEN = 78;
+    private const int SM_CYVIRTUALSCREEN = 79;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MOUSEINPUT
+    {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    // Union sized to the largest member so Marshal.SizeOf<INPUT>() matches what
+    // SendInput expects (same layout as in WindowsUInputKeyboard).
+    [StructLayout(LayoutKind.Explicit)]
+    private struct INPUTUNION
+    {
+        [FieldOffset(0)] public MOUSEINPUT mi;
+        [FieldOffset(0)] public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public uint type;
+        public INPUTUNION u;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [DllImport("user32.dll")]
+    private static extern int GetSystemMetrics(int nIndex);
+
+    private static readonly int InputSize = Marshal.SizeOf<INPUT>();
+
+    // SendInput requires no setup, so the backend is always available on Windows.
+    public bool Connected => true;
+
+    public void Click(MouseButton button)
+    {
+        var (down, up) = ButtonFlags(button);
+        Send([MouseInput(0, 0, 0, down), MouseInput(0, 0, 0, up)]);
+    }
+
+    public void ButtonDown(MouseButton button)
+    {
+        var (down, _) = ButtonFlags(button);
+        Send([MouseInput(0, 0, 0, down)]);
+    }
+
+    public void ButtonUp(MouseButton button)
+    {
+        var (_, up) = ButtonFlags(button);
+        Send([MouseInput(0, 0, 0, up)]);
+    }
+
+    public void MoveRelative(int dx, int dy)
+    {
+        Send([MouseInput(dx, dy, 0, MOUSEEVENTF_MOVE)]);
+    }
+
+    public void MoveAbsolute(int x, int y)
+    {
+        // Absolute coordinates are normalized to 0..65535 across the virtual desktop.
+        var left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        var top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        var width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        var height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+        if (width <= 0 || height <= 0)
+            return;
+
+        var nx = (int)Math.Round((x - left) * 65535.0 / width);
+        var ny = (int)Math.Round((y - top) * 65535.0 / height);
+
+        Send([MouseInput(nx, ny, 0, MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK)]);
+    }
+
+    public void Scroll(int amount)
+    {
+        Send([MouseInput(0, 0, unchecked((uint)(amount * WHEEL_DELTA)), MOUSEEVENTF_WHEEL)]);
+    }
+
+    public void Dispose()
+    {
+        // Nothing to dispose — SendInput holds no resources.
+    }
+
+    private static (uint down, uint up) ButtonFlags(MouseButton button) => button switch
+    {
+        MouseButton.Right => (MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP),
+        MouseButton.Middle => (MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP),
+        _ => (MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP)
+    };
+
+    private static INPUT MouseInput(int dx, int dy, uint mouseData, uint flags)
+    {
+        return new INPUT
+        {
+            type = INPUT_MOUSE,
+            u = new INPUTUNION
+            {
+                mi = new MOUSEINPUT
+                {
+                    dx = dx,
+                    dy = dy,
+                    mouseData = mouseData,
+                    dwFlags = flags
+                }
+            }
+        };
+    }
+
+    private static void Send(INPUT[] inputs)
+    {
+        if (inputs.Length == 0)
+            return;
+
+        SendInput((uint)inputs.Length, inputs, InputSize);
+    }
+}

--- a/Services/UInputKeyboard.cs
+++ b/Services/UInputKeyboard.cs
@@ -30,6 +30,17 @@ namespace LoupixDeck.Services
         /// </summary>
         /// <param name="keyNames">Ordered list of key names making up the combination.</param>
         void SendKeyCombination(IReadOnlyList<string> keyNames);
+
+        /// <summary>
+        /// Presses a key and keeps it held down until <see cref="KeyUp"/> is called for the
+        /// same key. Key names are resolved via <see cref="Utils.KeyNames"/>.
+        /// </summary>
+        void KeyDown(string keyName);
+
+        /// <summary>
+        /// Releases a key previously held down by <see cref="KeyDown"/>.
+        /// </summary>
+        void KeyUp(string keyName);
     }
 
     public class UInputKeyboard : IUInputKeyboard
@@ -259,6 +270,28 @@ namespace LoupixDeck.Services
                 ReleaseKey(codes[i]);
         }
 
+        public void KeyDown(string keyName)
+        {
+            if (!Connected)
+                return;
+
+            if (KeyNames.TryGetLinux(keyName, out var code))
+                PressKey(code);
+            else
+                Console.Error.WriteLine($"[UInputKeyboard] Unknown key name: '{keyName}'");
+        }
+
+        public void KeyUp(string keyName)
+        {
+            if (!Connected)
+                return;
+
+            if (KeyNames.TryGetLinux(keyName, out var code))
+                ReleaseKey(code);
+            else
+                Console.Error.WriteLine($"[UInputKeyboard] Unknown key name: '{keyName}'");
+        }
+
         public void Dispose()
         {
             if (_disposed) return;
@@ -480,6 +513,27 @@ namespace LoupixDeck.Services
                 inputs[i++] = KeyInput(keys[k].virtualKey, keys[k].extended, true);
 
             Send(inputs);
+        }
+
+        public void KeyDown(string keyName)
+        {
+            SendSingle(keyName, up: false);
+        }
+
+        public void KeyUp(string keyName)
+        {
+            SendSingle(keyName, up: true);
+        }
+
+        private void SendSingle(string keyName, bool up)
+        {
+            if (!Connected)
+                return;
+
+            if (KeyNames.TryGetWindows(keyName, out var virtualKey, out var extended))
+                Send([KeyInput(virtualKey, extended, up)]);
+            else
+                Console.Error.WriteLine($"[WindowsUInputKeyboard] Unknown key name: '{keyName}'");
         }
 
         public void Dispose()

--- a/Services/WindowsKeyboardRouter.cs
+++ b/Services/WindowsKeyboardRouter.cs
@@ -28,6 +28,10 @@ namespace LoupixDeck.Services
 
         public void SendKeyCombination(IReadOnlyList<string> keyNames) => Active.SendKeyCombination(keyNames);
 
+        public void KeyDown(string keyName) => Active.KeyDown(keyName);
+
+        public void KeyUp(string keyName) => Active.KeyUp(keyName);
+
         public void Dispose()
         {
             sendInput.Dispose();

--- a/ViewModels/MacroEditorViewModel.cs
+++ b/ViewModels/MacroEditorViewModel.cs
@@ -1,0 +1,313 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Input;
+using LoupixDeck.Models;
+using LoupixDeck.Models.Converter;
+using LoupixDeck.Models.Macros;
+using LoupixDeck.PluginSdk;
+using LoupixDeck.Services;
+using LoupixDeck.Services.Commands;
+using LoupixDeck.Services.Macros;
+using LoupixDeck.ViewModels.Base;
+using Newtonsoft.Json;
+
+namespace LoupixDeck.ViewModels;
+
+/// <summary>
+/// ViewModel of the visual macro editor. Works on deep copies of the macros and
+/// applies every valid change immediately (debounced) back into the
+/// <see cref="IMacroManager"/> — there is no explicit save step.
+/// </summary>
+public class MacroEditorViewModel : DialogViewModelBase<DialogResult>, IAsyncInitViewModel
+{
+    // Serializer used for deep-cloning macros (working copies).
+    private static readonly JsonSerializerSettings CloneSettings = new()
+    {
+        Converters = { new MacroStepJsonConverter() }
+    };
+
+    // Editor-only UI state on steps that must not trigger an auto-apply.
+    private static readonly HashSet<string> NonPersistedStepProperties =
+    [
+        nameof(MacroStep.IsEditing),
+        nameof(MacroStep.IsDragging),
+        nameof(MacroStep.ValueText)
+    ];
+
+    private readonly IMacroManager _macroManager;
+    private readonly ICommandBuilder _commandBuilder;
+    private readonly IMenuTreeBuilder _menuTreeBuilder;
+
+    // Debounces persisting while the user is typing; flushed on window close.
+    private readonly DispatcherTimer _applyTimer;
+
+    /// <summary>Editable working copies of all macros.</summary>
+    public ObservableCollection<Macro> Macros { get; } = [];
+
+    /// <summary>Command tree offered inside CommandStep editors.</summary>
+    public ObservableCollection<MenuEntry> SystemCommandMenus { get; } = [];
+
+    private Macro _selectedMacro;
+
+    public Macro SelectedMacro
+    {
+        get => _selectedMacro;
+        set
+        {
+            if (SetProperty(ref _selectedMacro, value))
+                OnPropertyChanged(nameof(HasSelectedMacro));
+        }
+    }
+
+    public bool HasSelectedMacro => SelectedMacro != null;
+
+    private string _validationMessage = string.Empty;
+
+    public string ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+                OnPropertyChanged(nameof(HasValidationMessage));
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+
+    public ICommand AddMacroCommand { get; }
+    public ICommand RemoveMacroCommand { get; }
+    public ICommand AddStepCommand { get; }
+
+    public MacroEditorViewModel(IMacroManager macroManager, ICommandBuilder commandBuilder,
+        IMenuTreeBuilder menuTreeBuilder)
+    {
+        _macroManager = macroManager;
+        _commandBuilder = commandBuilder;
+        _menuTreeBuilder = menuTreeBuilder;
+
+        foreach (var macro in macroManager.Macros)
+        {
+            var clone = DeepClone(macro);
+            Attach(clone);
+            Macros.Add(clone);
+        }
+
+        SelectedMacro = Macros.FirstOrDefault();
+
+        Macros.CollectionChanged += Macros_CollectionChanged;
+
+        _applyTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
+        _applyTimer.Tick += (_, _) =>
+        {
+            _applyTimer.Stop();
+            Apply();
+        };
+
+        AddMacroCommand = new RelayCommand(AddMacro);
+        RemoveMacroCommand = new RelayCommand(RemoveMacro);
+        AddStepCommand = new RelayCommand<string>(AddStep);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // TouchButton offers the richest command set for CommandStep editors.
+        await _menuTreeBuilder.BuildInto(SystemCommandMenus, ButtonTargets.TouchButton);
+    }
+
+    private void AddMacro()
+    {
+        var macro = new Macro { Name = GenerateMacroName() };
+        Macros.Add(macro);
+        SelectedMacro = macro;
+    }
+
+    private void RemoveMacro()
+    {
+        if (SelectedMacro == null)
+            return;
+
+        var index = Macros.IndexOf(SelectedMacro);
+        Macros.Remove(SelectedMacro);
+        SelectedMacro = Macros.Count > 0 ? Macros[Math.Min(index, Macros.Count - 1)] : null;
+    }
+
+    private void AddStep(string stepType)
+    {
+        if (SelectedMacro == null || !Enum.TryParse<MacroStepType>(stepType, out var type))
+            return;
+
+        MacroStep step = type switch
+        {
+            MacroStepType.Text => new TextStep(),
+            MacroStepType.KeyCombination => new KeyCombinationStep(),
+            MacroStepType.Delay => new DelayStep(),
+            MacroStepType.KeyDown => new KeyDownStep(),
+            MacroStepType.KeyUp => new KeyUpStep(),
+            MacroStepType.Mouse => new MouseStep(),
+            MacroStepType.Command => new CommandStep(),
+            _ => null
+        };
+
+        if (step == null)
+            return;
+
+        step.IsEditing = true;
+        SelectedMacro.Steps.Add(step);
+    }
+
+    public void RemoveStep(MacroStep step)
+    {
+        SelectedMacro?.Steps.Remove(step);
+    }
+
+    /// <summary>
+    /// Appends the command built from a menu entry to a CommandStep (double-click
+    /// in the step's system-command tree).
+    /// </summary>
+    public void InsertCommandIntoStep(CommandStep step, MenuEntry menuEntry)
+    {
+        if (step == null || menuEntry == null)
+            return;
+
+        var formattedCommand = _commandBuilder.CreateCommandFromMenuEntry(menuEntry);
+        if (string.IsNullOrEmpty(formattedCommand))
+            return;
+
+        step.CommandString = Utils.CommandChain.Append(step.CommandString, formattedCommand);
+    }
+
+    // ───────── Instant apply ─────────
+
+    private void Macros_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems != null)
+            foreach (Macro macro in e.OldItems)
+                Detach(macro);
+
+        if (e.NewItems != null)
+            foreach (Macro macro in e.NewItems)
+                Attach(macro);
+
+        ScheduleApply();
+    }
+
+    private void Attach(Macro macro)
+    {
+        macro.PropertyChanged += Macro_PropertyChanged;
+        macro.Steps.CollectionChanged += Steps_CollectionChanged;
+        foreach (var step in macro.Steps)
+            step.PropertyChanged += Step_PropertyChanged;
+    }
+
+    private void Detach(Macro macro)
+    {
+        macro.PropertyChanged -= Macro_PropertyChanged;
+        macro.Steps.CollectionChanged -= Steps_CollectionChanged;
+        foreach (var step in macro.Steps)
+            step.PropertyChanged -= Step_PropertyChanged;
+    }
+
+    private void Macro_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(Macro.Name))
+            ScheduleApply();
+    }
+
+    private void Steps_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems != null)
+            foreach (MacroStep step in e.OldItems)
+                step.PropertyChanged -= Step_PropertyChanged;
+
+        if (e.NewItems != null)
+            foreach (MacroStep step in e.NewItems)
+                step.PropertyChanged += Step_PropertyChanged;
+
+        ScheduleApply();
+    }
+
+    private void Step_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (!NonPersistedStepProperties.Contains(e.PropertyName))
+            ScheduleApply();
+    }
+
+    /// <summary>
+    /// Validates immediately (for instant feedback at the name box) and schedules a
+    /// debounced apply. Invalid working sets are never pushed to the manager — the
+    /// last valid state stays persisted until the input is fixed.
+    /// </summary>
+    private void ScheduleApply()
+    {
+        _applyTimer.Stop();
+
+        if (!Validate())
+            return;
+
+        _applyTimer.Start();
+    }
+
+    private void Apply()
+    {
+        // Push clones so the manager never shares instances with the editor's working set.
+        _macroManager.ReplaceAll(Macros.Select(DeepClone));
+    }
+
+    /// <summary>Persists a pending (debounced) apply. Called when the editor window closes.</summary>
+    public void FlushPendingChanges()
+    {
+        if (!_applyTimer.IsEnabled)
+            return;
+
+        _applyTimer.Stop();
+
+        if (Validate())
+            Apply();
+    }
+
+    private bool Validate()
+    {
+        foreach (var macro in Macros)
+        {
+            if (!MacroManager.HasValidNameCharacters(macro.Name))
+            {
+                ValidationMessage =
+                    $"Invalid macro name '{macro.Name}': names must not be empty or contain ( ) , &";
+                return false;
+            }
+        }
+
+        var duplicate = Macros
+            .GroupBy(m => m.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate != null)
+        {
+            ValidationMessage = $"Duplicate macro name '{duplicate.Key}'.";
+            return false;
+        }
+
+        ValidationMessage = string.Empty;
+        return true;
+    }
+
+    private string GenerateMacroName()
+    {
+        const string baseName = "New Macro";
+        var name = baseName;
+        var counter = 2;
+        while (Macros.Any(m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)))
+            name = $"{baseName} {counter++}";
+        return name;
+    }
+
+    private static Macro DeepClone(Macro macro)
+    {
+        var json = JsonConvert.SerializeObject(macro, CloneSettings);
+        return JsonConvert.DeserializeObject<Macro>(json, CloneSettings);
+    }
+}

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,7 @@ public class MainWindowViewModel : ViewModelBase
     public ICommand TouchPageButtonCommand { get; }
 
     public ICommand SettingsMenuCommand { get; }
+    public ICommand MacroEditorMenuCommand { get; }
     public ICommand AboutMenuCommand { get; }
     public ICommand QuitApplicationCommand { get; }
     public ICommand ToggleDeviceStateCommand { get; }
@@ -116,6 +117,7 @@ public class MainWindowViewModel : ViewModelBase
         TouchPageButtonCommand = new RelayCommand<int>(TouchPageButton_Click);
 
         SettingsMenuCommand = new AsyncRelayCommand(SettingsMenuButton_Click);
+        MacroEditorMenuCommand = new AsyncRelayCommand(MacroEditorMenuButton_Click);
         AboutMenuCommand = new AsyncRelayCommand(AboutMenuButton_Click);
         QuitApplicationCommand = new RelayCommand(QuitApplication);
         ToggleDeviceStateCommand = new AsyncRelayCommand(LoupedeckController.ToggleDeviceState);
@@ -211,6 +213,12 @@ public class MainWindowViewModel : ViewModelBase
     {
         await _dialogService.ShowDialogAsync<SettingsViewModel, DialogResult>();
         LoupedeckController.SaveConfig();
+    }
+
+    private async Task MacroEditorMenuButton_Click()
+    {
+        // Macros persist in their own macros.json — no SaveConfig needed here.
+        await _dialogService.ShowDialogAsync<MacroEditorViewModel, DialogResult>();
     }
     
     private async Task AboutMenuButton_Click()

--- a/Views/MacroEditor.axaml
+++ b/Views/MacroEditor.axaml
@@ -1,0 +1,424 @@
+<Window
+    x:Class="LoupixDeck.Views.MacroEditor"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:LoupixDeck.ViewModels"
+    xmlns:macros="using:LoupixDeck.Models.Macros"
+    xmlns:models="using:LoupixDeck.Models"
+    x:DataType="vm:MacroEditorViewModel"
+    Title="Macro Editor"
+    Width="980"
+    Height="700"
+    mc:Ignorable="d"
+    SystemDecorations="Full"
+    CanResize="True"
+    MinWidth="820"
+    MinHeight="560">
+
+    <Window.Styles>
+        <StyleInclude Source="avares://LoupixDeck/Views/Styles/SettingsStyles.axaml" />
+
+        <!-- Step panel -->
+        <Style Selector="Border.step-panel">
+            <Setter Property="Background" Value="#262626" />
+            <Setter Property="BorderBrush" Value="#3A3A3A" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+            <Setter Property="Padding" Value="10,4" />
+        </Style>
+        <Style Selector="Border.step-panel.dragging">
+            <Setter Property="Opacity" Value="0.55" />
+            <Setter Property="BorderBrush" Value="#4DA3FF" />
+        </Style>
+
+        <Style Selector="TextBlock.step-icon">
+            <Setter Property="FontFamily" Value="{StaticResource MdiFont}" />
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBlock.step-type">
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBlock.step-value">
+            <Setter Property="Foreground" Value="#A0A0A0" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+
+        <Style Selector="Border.drag-handle">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Cursor" Value="SizeAll" />
+            <Setter Property="Padding" Value="6,0" />
+        </Style>
+        <Style Selector="Border.drag-handle TextBlock">
+            <Setter Property="Foreground" Value="#707070" />
+        </Style>
+        <Style Selector="Border.drag-handle:pointerover TextBlock">
+            <Setter Property="Foreground" Value="#C0C0C0" />
+        </Style>
+
+        <Style Selector="Border.step-editor">
+            <Setter Property="BorderBrush" Value="#3A3A3A" />
+            <Setter Property="BorderThickness" Value="0,1,0,0" />
+            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="Padding" Value="2,8,2,4" />
+        </Style>
+
+        <Style Selector="TextBlock.editor-label">
+            <Setter Property="Foreground" Value="#A0A0A0" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <!-- Collapse/expand toggle on each step panel -->
+        <Style Selector="ToggleButton.step-expand">
+            <Setter Property="Background" Value="#333" />
+            <Setter Property="BorderBrush" Value="#444" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Width" Value="28" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Margin" Value="0,0,4,0" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontFamily" Value="{StaticResource MdiFont}" />
+            <Setter Property="Content" Value="&#xF0140;" />
+            <!-- mdi-chevron-down -->
+        </Style>
+        <Style Selector="ToggleButton.step-expand:checked">
+            <Setter Property="Content" Value="&#xF0143;" />
+            <!-- mdi-chevron-up -->
+        </Style>
+        <Style Selector="ToggleButton.step-expand:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#3F3F3F" />
+        </Style>
+        <Style Selector="ToggleButton.step-expand:checked /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#333" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="ToggleButton.step-expand:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#3F3F3F" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+
+        <!-- Invalid-input highlight (macro name) -->
+        <Style Selector="TextBox.error /template/ Border#PART_BorderElement">
+            <Setter Property="BorderBrush" Value="#E05A5A" />
+        </Style>
+        <Style Selector="TextBox.error:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="BorderBrush" Value="#E05A5A" />
+        </Style>
+        <Style Selector="TextBox.error:focus /template/ Border#PART_BorderElement">
+            <Setter Property="BorderBrush" Value="#E05A5A" />
+        </Style>
+
+        <Style Selector="TextBlock.validation-error">
+            <Setter Property="Foreground" Value="#F08A8A" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,*" Margin="14">
+
+        <!-- Title -->
+        <TextBlock Grid.Row="0" Classes="page-title" Text="Macro Editor" />
+
+        <!-- Main content: macro list | step editor -->
+        <Grid Grid.Row="1" ColumnDefinitions="260,*">
+
+            <!-- Left: macro list -->
+            <Border Grid.Column="0" Classes="card" Margin="0,0,12,0" Padding="10">
+                <Grid RowDefinitions="Auto,*,Auto">
+                    <TextBlock Grid.Row="0" Classes="card-title" Text="Macros" />
+
+                    <ListBox Grid.Row="1"
+                             ItemsSource="{Binding Macros}"
+                             SelectedItem="{Binding SelectedMacro, Mode=TwoWay}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type macros:Macro}">
+                                <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <Grid Grid.Row="2" ColumnDefinitions="*,*" Margin="0,8,0,0">
+                        <Button Grid.Column="0"
+                                Content="Add Macro"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                Margin="0,0,4,0"
+                                Command="{Binding AddMacroCommand}" />
+                        <Button Grid.Column="1"
+                                Content="Remove"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                Margin="4,0,0,0"
+                                Background="#3A2424"
+                                Foreground="#E08A8A"
+                                IsEnabled="{Binding HasSelectedMacro}"
+                                Command="{Binding RemoveMacroCommand}" />
+                    </Grid>
+                </Grid>
+            </Border>
+
+            <!-- Right: steps of the selected macro -->
+            <Border Grid.Column="1" Classes="card" Margin="0" Padding="14"
+                    IsVisible="{Binding HasSelectedMacro}">
+                <Grid RowDefinitions="Auto,Auto,*">
+
+                    <!-- Name -->
+                    <Grid Grid.Row="0" RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*" Margin="0,0,0,10">
+                        <TextBlock Grid.Row="0" Grid.Column="0" Classes="editor-label" Text="Name" Margin="0,0,10,0" />
+                        <TextBox Grid.Row="0" Grid.Column="1"
+                                 Classes.error="{Binding HasValidationMessage}"
+                                 Text="{Binding SelectedMacro.Name, Mode=TwoWay}" />
+                        <TextBlock Grid.Row="1" Grid.Column="1"
+                                   Classes="validation-error"
+                                   Margin="0,4,0,0"
+                                   Text="{Binding ValidationMessage}"
+                                   IsVisible="{Binding HasValidationMessage}" />
+                    </Grid>
+
+                    <!-- Steps header + add button -->
+                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                        <TextBlock Grid.Column="0" Classes="card-title" Text="Steps" VerticalAlignment="Center"
+                                   Margin="0" />
+                        <Button Grid.Column="1" Content="Add Step ▾">
+                            <Button.Flyout>
+                                <MenuFlyout Placement="BottomEdgeAlignedRight">
+                                    <MenuItem Header="Type Text" Tag="Text" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Key Combination" Tag="KeyCombination" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Key Down" Tag="KeyDown" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Key Up" Tag="KeyUp" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Delay" Tag="Delay" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Mouse" Tag="Mouse" Click="AddStepMenu_Click" />
+                                    <MenuItem Header="Command" Tag="Command" Click="AddStepMenu_Click" />
+                                </MenuFlyout>
+                            </Button.Flyout>
+                        </Button>
+                    </Grid>
+
+                    <!-- Step list -->
+                    <ScrollViewer Grid.Row="2"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel>
+                            <ItemsControl Name="StepsList"
+                                          ItemsSource="{Binding SelectedMacro.Steps}"
+                                          PointerMoved="StepsList_PointerMoved"
+                                          PointerReleased="StepsList_PointerReleased"
+                                          PointerCaptureLost="StepsList_PointerCaptureLost">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type macros:MacroStep}">
+                                        <Border Classes="step-panel" Classes.dragging="{Binding IsDragging}">
+                                            <Grid RowDefinitions="Auto,Auto">
+
+                                                <!-- Panel row: icon | type | value | expand | remove | drag handle -->
+                                                <Grid Grid.Row="0"
+                                                      ColumnDefinitions="36,150,*,Auto,Auto,Auto"
+                                                      MinHeight="36">
+                                                    <TextBlock Grid.Column="0" Classes="step-icon"
+                                                               Text="{Binding Icon}" />
+                                                    <TextBlock Grid.Column="1" Classes="step-type"
+                                                               Text="{Binding TypeText}" />
+                                                    <TextBlock Grid.Column="2" Classes="step-value"
+                                                               Text="{Binding ValueText}" />
+
+                                                    <ToggleButton Grid.Column="3" Classes="step-expand"
+                                                                  VerticalAlignment="Center"
+                                                                  ToolTip.Tip="Expand / collapse step editor"
+                                                                  IsChecked="{Binding IsEditing, Mode=TwoWay}" />
+
+                                                    <Button Grid.Column="4" Classes="row-action danger"
+                                                            FontFamily="{StaticResource MdiFont}"
+                                                            Content="&#xF01B4;"
+                                                            VerticalAlignment="Center"
+                                                            ToolTip.Tip="Remove step"
+                                                            Click="RemoveStep_Click" />
+
+                                                    <Border Grid.Column="5" Classes="drag-handle"
+                                                            VerticalAlignment="Stretch"
+                                                            PointerPressed="DragHandle_PointerPressed">
+                                                        <TextBlock Classes="step-icon" Text="&#xF01DB;" />
+                                                    </Border>
+                                                </Grid>
+
+                                                <!-- Inline editor (expanded via Edit) -->
+                                                <Border Grid.Row="1" Classes="step-editor"
+                                                        IsVisible="{Binding IsEditing}">
+                                                    <ContentControl Content="{Binding}">
+                                                        <ContentControl.DataTemplates>
+
+                                                            <DataTemplate DataType="{x:Type macros:TextStep}">
+                                                                <Grid ColumnDefinitions="Auto,*">
+                                                                    <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                               Text="Text" Margin="0,0,10,0" />
+                                                                    <TextBox Grid.Column="1"
+                                                                             Text="{Binding Text, Mode=TwoWay}" />
+                                                                </Grid>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:KeyCombinationStep}">
+                                                                <StackPanel Spacing="4">
+                                                                    <Grid ColumnDefinitions="Auto,*">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Keys" Margin="0,0,10,0" />
+                                                                        <TextBox Grid.Column="1"
+                                                                                 Text="{Binding Keys, Mode=TwoWay}" />
+                                                                    </Grid>
+                                                                    <TextBlock Classes="hint"
+                                                                               Text="Key names joined with '+', e.g. Ctrl+Shift+Esc or Tab or Enter." />
+                                                                </StackPanel>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:DelayStep}">
+                                                                <Grid ColumnDefinitions="Auto,Auto,Auto">
+                                                                    <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                               Text="Duration" Margin="0,0,10,0" />
+                                                                    <NumericUpDown Grid.Column="1" Width="140"
+                                                                                   Minimum="0" Maximum="600000"
+                                                                                   Increment="50" FormatString="0"
+                                                                                   Value="{Binding Milliseconds, Mode=TwoWay}" />
+                                                                    <TextBlock Grid.Column="2" Classes="editor-label"
+                                                                               Text="ms" Margin="8,0,0,0" />
+                                                                </Grid>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:KeyDownStep}">
+                                                                <StackPanel Spacing="4">
+                                                                    <Grid ColumnDefinitions="Auto,*">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Key" Margin="0,0,10,0" />
+                                                                        <TextBox Grid.Column="1"
+                                                                                 Text="{Binding Key, Mode=TwoWay}" />
+                                                                    </Grid>
+                                                                    <TextBlock Classes="hint"
+                                                                               Text="Single key name to hold down, e.g. Shift, Ctrl, A. Release it with a Key Up step." />
+                                                                </StackPanel>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:KeyUpStep}">
+                                                                <StackPanel Spacing="4">
+                                                                    <Grid ColumnDefinitions="Auto,*">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Key" Margin="0,0,10,0" />
+                                                                        <TextBox Grid.Column="1"
+                                                                                 Text="{Binding Key, Mode=TwoWay}" />
+                                                                    </Grid>
+                                                                    <TextBlock Classes="hint"
+                                                                               Text="Single key name to release, e.g. Shift, Ctrl, A." />
+                                                                </StackPanel>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:MouseStep}">
+                                                                <StackPanel Spacing="6">
+                                                                    <Grid ColumnDefinitions="Auto,180,20,Auto,180">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Action" Margin="0,0,10,0" />
+                                                                        <ComboBox Grid.Column="1"
+                                                                                  HorizontalAlignment="Stretch"
+                                                                                  ItemsSource="{x:Static macros:MouseStep.AllActions}"
+                                                                                  SelectedItem="{Binding Action, Mode=TwoWay}" />
+                                                                        <TextBlock Grid.Column="3" Classes="editor-label"
+                                                                                   Text="Button" Margin="0,0,10,0"
+                                                                                   IsVisible="{Binding ShowsButton}" />
+                                                                        <ComboBox Grid.Column="4"
+                                                                                  HorizontalAlignment="Stretch"
+                                                                                  ItemsSource="{x:Static macros:MouseStep.AllButtons}"
+                                                                                  SelectedItem="{Binding Button, Mode=TwoWay}"
+                                                                                  IsVisible="{Binding ShowsButton}" />
+                                                                    </Grid>
+                                                                    <Grid ColumnDefinitions="Auto,140,20,Auto,140"
+                                                                          IsVisible="{Binding ShowsCoordinates}">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="X" Margin="0,0,10,0" />
+                                                                        <NumericUpDown Grid.Column="1"
+                                                                                       Minimum="-100000" Maximum="100000"
+                                                                                       Increment="10" FormatString="0"
+                                                                                       Value="{Binding X, Mode=TwoWay}" />
+                                                                        <TextBlock Grid.Column="3" Classes="editor-label"
+                                                                                   Text="Y" Margin="0,0,10,0" />
+                                                                        <NumericUpDown Grid.Column="4"
+                                                                                       Minimum="-100000" Maximum="100000"
+                                                                                       Increment="10" FormatString="0"
+                                                                                       Value="{Binding Y, Mode=TwoWay}" />
+                                                                    </Grid>
+                                                                    <Grid ColumnDefinitions="Auto,140,Auto"
+                                                                          IsVisible="{Binding ShowsAmount}">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Amount" Margin="0,0,10,0" />
+                                                                        <NumericUpDown Grid.Column="1"
+                                                                                       Minimum="-100" Maximum="100"
+                                                                                       Increment="1" FormatString="0"
+                                                                                       Value="{Binding Amount, Mode=TwoWay}" />
+                                                                        <TextBlock Grid.Column="2" Classes="editor-label"
+                                                                                   Text="wheel detents (+ up / - down)"
+                                                                                   Margin="8,0,0,0" />
+                                                                    </Grid>
+                                                                    <TextBlock Classes="hint"
+                                                                               IsVisible="{Binding ShowsAbsoluteHint}"
+                                                                               Text="Absolute positioning is not supported on Linux (the step is skipped there)." />
+                                                                </StackPanel>
+                                                            </DataTemplate>
+
+                                                            <DataTemplate DataType="{x:Type macros:CommandStep}">
+                                                                <StackPanel Spacing="6">
+                                                                    <Grid ColumnDefinitions="Auto,*">
+                                                                        <TextBlock Grid.Column="0" Classes="editor-label"
+                                                                                   Text="Command" Margin="0,0,10,0" />
+                                                                        <TextBox Grid.Column="1"
+                                                                                 Text="{Binding CommandString, Mode=TwoWay}" />
+                                                                    </Grid>
+                                                                    <TextBlock Classes="hint"
+                                                                               Text="A LoupixDeck system command or any shell command. Double-click an entry below to insert it." />
+                                                                    <Expander Header="System Commands">
+                                                                        <TreeView MaxHeight="240"
+                                                                                  Tag="{Binding}"
+                                                                                  ItemsSource="{Binding $parent[Window].((vm:MacroEditorViewModel)DataContext).SystemCommandMenus}">
+                                                                            <TreeView.DataTemplates>
+                                                                                <TreeDataTemplate DataType="{x:Type models:MenuEntry}"
+                                                                                                  ItemsSource="{Binding Children}">
+                                                                                    <StackPanel Orientation="Horizontal"
+                                                                                                PointerPressed="CommandTree_PointerPressed">
+                                                                                        <TextBlock Text="{Binding Name}" />
+                                                                                        <TextBlock Text="(loading…)" Margin="6,0,0,0"
+                                                                                                   Foreground="Gray" FontStyle="Italic"
+                                                                                                   IsVisible="{Binding IsLoading}" />
+                                                                                    </StackPanel>
+                                                                                </TreeDataTemplate>
+                                                                            </TreeView.DataTemplates>
+                                                                        </TreeView>
+                                                                    </Expander>
+                                                                </StackPanel>
+                                                            </DataTemplate>
+
+                                                        </ContentControl.DataTemplates>
+                                                    </ContentControl>
+                                                </Border>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Empty state -->
+                            <TextBlock Classes="hint"
+                                       Margin="2,4,0,0"
+                                       Text="No steps yet — use “Add Step” to build the macro. Drag the handle on the right of a step to reorder."
+                                       IsVisible="{Binding !SelectedMacro.Steps.Count}" />
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</Window>

--- a/Views/MacroEditor.axaml.cs
+++ b/Views/MacroEditor.axaml.cs
@@ -1,0 +1,170 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using LoupixDeck.Models;
+using LoupixDeck.Models.Macros;
+using LoupixDeck.ViewModels;
+using LoupixDeck.ViewModels.Base;
+
+namespace LoupixDeck.Views;
+
+public partial class MacroEditor : Window
+{
+    // Step currently being dragged via its drag handle; null when no drag is active.
+    private MacroStep _draggedStep;
+
+    public MacroEditor() : this(null)
+    {
+    }
+
+    public MacroEditor(MacroEditorViewModel vm)
+    {
+        // Set DataContext before XAML load so $parent[Window].DataContext bindings
+        // in DataTemplates have a non-null target on first evaluation.
+        if (vm != null)
+            DataContext = vm;
+
+        InitializeComponent();
+
+        Closing += (_, _) =>
+        {
+            // Changes apply instantly (debounced) — persist anything still pending.
+            ViewModel?.FlushPendingChanges();
+
+            if (DataContext is IDialogViewModel dlg && !dlg.DialogResult.Task.IsCompleted)
+            {
+                dlg.DialogResult.TrySetResult(new DialogResult(true));
+            }
+        };
+    }
+
+    private MacroEditorViewModel ViewModel => DataContext as MacroEditorViewModel;
+
+    // ───────── Add / Edit / Remove steps ─────────
+
+    private void AddStepMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { Tag: string stepType })
+            ViewModel?.AddStepCommand.Execute(stepType);
+    }
+
+    private void RemoveStep_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button { DataContext: MacroStep step })
+            ViewModel?.RemoveStep(step);
+    }
+
+    // ───────── Command tree (CommandStep editor) ─────────
+
+    private void CommandTree_PointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (e.ClickCount != 2)
+            return;
+
+        if (e.Source is not TextBlock { DataContext: MenuEntry menuEntry } textBlock ||
+            string.IsNullOrWhiteSpace(menuEntry.Command))
+            return;
+
+        // The TreeView's Tag carries the CommandStep this tree belongs to.
+        var treeView = textBlock.FindAncestorOfType<TreeView>();
+        if (treeView?.Tag is CommandStep step)
+            ViewModel?.InsertCommandIntoStep(step, menuEntry);
+    }
+
+    // ───────── Drag & drop live reorder ─────────
+    //
+    // The drag handle captures the pointer onto the steps ItemsControl (a stable
+    // control that survives collection moves), then every PointerMoved maps the
+    // pointer position to a target index and moves the dragged step there
+    // immediately — the list reorders live while dragging.
+
+    private void DragHandle_PointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Control { DataContext: MacroStep step })
+            return;
+
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            return;
+
+        _draggedStep = step;
+        step.IsDragging = true;
+
+        // Capture on the ItemsControl: containers may be recycled during moves,
+        // but the list itself stays alive for the whole drag.
+        e.Pointer.Capture(StepsList);
+        e.Handled = true;
+    }
+
+    private void StepsList_PointerMoved(object sender, PointerEventArgs e)
+    {
+        if (_draggedStep == null)
+            return;
+
+        var steps = ViewModel?.SelectedMacro?.Steps;
+        if (steps == null)
+            return;
+
+        var currentIndex = steps.IndexOf(_draggedStep);
+        if (currentIndex < 0)
+            return;
+
+        var targetIndex = FindTargetIndex(e, currentIndex, steps.Count);
+        if (targetIndex != currentIndex)
+            steps.Move(currentIndex, targetIndex);
+    }
+
+    private void StepsList_PointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        EndDrag(e.Pointer);
+    }
+
+    private void StepsList_PointerCaptureLost(object sender, PointerCaptureLostEventArgs e)
+    {
+        EndDrag(null);
+    }
+
+    private void EndDrag(IPointer pointer)
+    {
+        if (_draggedStep == null)
+            return;
+
+        _draggedStep.IsDragging = false;
+        _draggedStep = null;
+        pointer?.Capture(null);
+    }
+
+    /// <summary>
+    /// Maps the pointer position to the index the dragged step should occupy.
+    /// Uses container midpoints as switch thresholds so the order only changes
+    /// once the pointer has clearly entered a neighbouring panel (no flicker
+    /// with differently sized panels, e.g. expanded inline editors).
+    /// </summary>
+    private int FindTargetIndex(PointerEventArgs e, int currentIndex, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            if (i == currentIndex)
+                continue;
+
+            var container = StepsList.ContainerFromIndex(i);
+            if (container == null)
+                continue;
+
+            var position = e.GetPosition(container);
+            if (position.Y < 0 || position.Y > container.Bounds.Height)
+                continue;
+
+            var midpoint = container.Bounds.Height / 2;
+
+            // Dragging upwards: switch once the pointer is in the upper half of the
+            // hovered panel; downwards: once it is in the lower half.
+            if (i < currentIndex && position.Y < midpoint)
+                return i;
+            if (i > currentIndex && position.Y > midpoint)
+                return i;
+        }
+
+        return currentIndex;
+    }
+}

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -61,6 +61,11 @@
                                 FontSize="18"
                                 Content="Settings"
                                 Command="{Binding SettingsMenuCommand}" />
+                        <Button Width="100" Height="40" VerticalContentAlignment="Center" Margin="0,5,0,0"
+                                HorizontalContentAlignment="Center"
+                                FontSize="18"
+                                Content="Macros"
+                                Command="{Binding MacroEditorMenuCommand}" />
                         <Separator />
                         <Button Width="100" Height="40" VerticalContentAlignment="Center"
                                 HorizontalContentAlignment="Center"


### PR DESCRIPTION
Introduces a macro system with its own persistence (macros.json) and a visual editor dialog:

- Macro model with typed steps (text, key combination, key down/up, delay, mouse, command) and JSON discriminator-based serialization
- MacroManager service for loading, validating and persisting macros; macros are invokable via System.Macro(Name) and appear in the command menu tree
- MacroRunner executing steps through the virtual keyboard/mouse backends (uinput on Linux, Interception/SendInput on Windows)
- Virtual mouse abstraction (IVirtualMouse) for Linux and Windows
- Macro editor window with step list, inline step editors, drag-and-drop reordering, collapse/expand per step and instant (debounced) apply without a save button; name validation shows inline with a red input border