### PR TITLE
Add comprehensive Loupedeck CT device support

### DIFF
--- a/.agents/skills/loupixdeck-issue-checks/SKILL.md
+++ b/.agents/skills/loupixdeck-issue-checks/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: loupixdeck-issue-checks
+description: Investigate and fix LoupixDeck issues with mandatory local validation checks before finalizing.
+---
+
+# LoupixDeck issue triage and checks
+You are working in the LoupixDeck repository.
+
+When given an issue:
+1. Reproduce and diagnose the issue from code and available context.
+2. Implement the smallest safe fix.
+3. Run required checks before concluding:
+   - `dotnet restore LoupixDeck.sln`
+   - `dotnet build LoupixDeck.sln -c Release`
+4. If any `*Test*.csproj` or `*Tests*.csproj` projects exist, also run:
+   - `dotnet test LoupixDeck.sln -c Release`
+5. In your final summary, include:
+   - root cause
+   - what changed
+   - exact check commands run and their results
+
+Constraints:
+- Do not skip validation commands unless command execution is genuinely blocked by environment constraints.
+- If a check fails, include the failing command output details and next remediation steps.

--- a/App.axaml
+++ b/App.axaml
@@ -79,6 +79,7 @@
                     <!-- Baked body artwork chosen per theme (see tools/BodyTextureBaker). -->
                     <x:String x:Key="DeviceBodySvgPath">avares://LoupixDeck/Assets/loupedeck-gehaeuse.svg</x:String>
                     <x:String x:Key="RazerBodySvgPath">avares://LoupixDeck/Assets/razer-gehaeuse.svg</x:String>
+                    <x:String x:Key="LoupedeckCtBodySvgPath">avares://LoupixDeck/Assets/loupedeck-ct-gehaeuse.svg</x:String>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <SolidColorBrush x:Key="AppWindowBackground" Color="#F3F3F3" />
@@ -110,6 +111,7 @@
                     <!-- Baked body artwork chosen per theme (see tools/BodyTextureBaker). -->
                     <x:String x:Key="DeviceBodySvgPath">avares://LoupixDeck/Assets/loupedeck-gehaeuse-light.svg</x:String>
                     <x:String x:Key="RazerBodySvgPath">avares://LoupixDeck/Assets/razer-gehaeuse-light.svg</x:String>
+                    <x:String x:Key="LoupedeckCtBodySvgPath">avares://LoupixDeck/Assets/loupedeck-ct-gehaeuse-light.svg</x:String>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 

--- a/Assets/loupedeck-ct-gehaeuse-light.svg
+++ b/Assets/loupedeck-ct-gehaeuse-light.svg
@@ -1,0 +1,12 @@
+<!-- Placeholder chassis art for the Loupedeck CT (light theme) — see
+     loupedeck-ct-gehaeuse.svg for why this is flat rather than a baked photo. -->
+<svg viewBox="0 0 900 760" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="bodyShadow" x="-25%" y="-25%" width="150%" height="160%">
+            <feDropShadow dx="0" dy="8" stdDeviation="14" flood-color="#000000" flood-opacity="0.45"/>
+        </filter>
+    </defs>
+    <g filter="url(#bodyShadow)">
+        <rect x="60" y="40" width="780" height="690" rx="42" ry="42" fill="#d9d9d9"/>
+    </g>
+</svg>

--- a/Assets/loupedeck-ct-gehaeuse.svg
+++ b/Assets/loupedeck-ct-gehaeuse.svg
@@ -1,0 +1,14 @@
+<!-- Placeholder chassis art for the Loupedeck CT — a flat shape, not a baked product
+     photo like the other devices' *-gehaeuse.svg (see tools/BodyTextureBaker). No CT
+     product photo was available while adding this device; replace with a baked
+     texture once one is. ViewBox matches LoupedeckCtLayout.axaml's 900x760 Grid. -->
+<svg viewBox="0 0 900 760" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="bodyShadow" x="-25%" y="-25%" width="150%" height="160%">
+            <feDropShadow dx="0" dy="8" stdDeviation="14" flood-color="#000000" flood-opacity="0.45"/>
+        </filter>
+    </defs>
+    <g filter="url(#bodyShadow)">
+        <rect x="60" y="40" width="780" height="690" rx="42" ry="42" fill="#151414"/>
+    </g>
+</svg>

--- a/Controllers/LoupedeckLiveSController.cs
+++ b/Controllers/LoupedeckLiveSController.cs
@@ -1165,6 +1165,8 @@ public partial class LoupedeckLiveSController(
             case Constants.ButtonType.KNOB_TR: index = 3; return true;
             case Constants.ButtonType.KNOB_CR: index = 4; return true;
             case Constants.ButtonType.KNOB_BR: index = 5; return true;
+            // Loupedeck CT's centre wheel is a 7th rotary, slotted after the 6 side dials.
+            case Constants.ButtonType.KNOB_CT: index = 6; return true;
             default: index = -1; return false;
         }
     }
@@ -1584,12 +1586,53 @@ public partial class LoupedeckLiveSController(
     /// <summary>
     /// Builds the SimpleButton array sized to the active device's physical button count.
     /// The first four slots get the page-navigation defaults that existed for the Live S;
-    /// any additional slots (e.g. Razer's BUTTON4–BUTTON7) are created blank for the
-    /// user to assign — preserves saved bindings via SimpleButtonExtensions.FindById.
+    /// any additional slots (e.g. Razer's BUTTON4–BUTTON7, the CT's 12 named buttons) are
+    /// created blank for the user to assign — preserves saved bindings via
+    /// SimpleButtonExtensions.FindById.
     /// </summary>
     private async Task<SimpleButton[]> BuildSimpleButtons()
     {
         var device = deviceService.Device;
+
+        // The Loupedeck CT has 8 round + 12 named square buttons (20 total, sized via
+        // its own Buttons[] in LoupedeckCtDevice) — give the 8 round ones the same
+        // numeric-page-selector defaults as Razer/Live, and leave the 12 named ones
+        // blank since their physical labels (home/undo/save/...) don't map to an
+        // obvious default command.
+        if (device is LoupedeckDevice.Device.LoupedeckCtDevice)
+        {
+            var ctDefaults = new (Constants.ButtonType Id, string Cmd)[]
+            {
+                (Constants.ButtonType.BUTTON0, "System.GotoPage(1)"),
+                (Constants.ButtonType.BUTTON1, "System.GotoPage(2)"),
+                (Constants.ButtonType.BUTTON2, "System.GotoPage(3)"),
+                (Constants.ButtonType.BUTTON3, "System.GotoPage(4)"),
+                (Constants.ButtonType.BUTTON4, "System.GotoPage(5)"),
+                (Constants.ButtonType.BUTTON5, "System.GotoPage(6)"),
+                (Constants.ButtonType.BUTTON6, "System.GotoPage(7)"),
+                (Constants.ButtonType.BUTTON7, "System.NextPage"),
+                (Constants.ButtonType.CT_HOME, null),
+                (Constants.ButtonType.CT_UNDO, null),
+                (Constants.ButtonType.CT_KEYBOARD, null),
+                (Constants.ButtonType.CT_ENTER, null),
+                (Constants.ButtonType.CT_SAVE, null),
+                (Constants.ButtonType.CT_FN_L, null),
+                (Constants.ButtonType.CT_A, null),
+                (Constants.ButtonType.CT_B, null),
+                (Constants.ButtonType.CT_C, null),
+                (Constants.ButtonType.CT_D, null),
+                (Constants.ButtonType.CT_FN_R, null),
+                (Constants.ButtonType.CT_E, null)
+            };
+
+            var ctCount = device.Buttons?.Length ?? 0;
+            var ctResult = new SimpleButton[ctCount];
+            for (var i = 0; i < ctCount && i < ctDefaults.Length; i++)
+            {
+                ctResult[i] = await CreateSimpleButton(ctDefaults[i].Id, Avalonia.Media.Colors.Blue, ctDefaults[i].Cmd ?? string.Empty);
+            }
+            return ctResult;
+        }
 
         // The eight-button devices (Razer Stream Controller and Loupedeck Live, which
         // subclasses it) default their buttons to numeric profile (touch-page) selectors;

--- a/LoupedeckDevice/Constants.cs
+++ b/LoupedeckDevice/Constants.cs
@@ -19,7 +19,28 @@ public static class Constants
         BUTTON4 = 10,
         BUTTON5 = 11,
         BUTTON6 = 12,
-        BUTTON7 = 13
+        BUTTON7 = 13,
+
+        // Loupedeck CT only. The 12 named square buttons plus KNOB_CT (the centre
+        // wheel's rotate identity) — confirmed against real hardware via a serial
+        // trace (LOUPIXDECK_DEBUG_PROTOCOL=1). The wheel has no separate "click"
+        // button code: pressing it shows up as a tight cluster of touch
+        // start/end events near the centre of its own screen (command bytes
+        // 0x52/0x72 — see Command.WHEEL_TOUCH below), not as a BUTTON_PRESS.
+        // Detecting a "click" from that touch cluster is not yet implemented.
+        CT_HOME = 14,
+        CT_UNDO = 15,
+        CT_KEYBOARD = 16,
+        CT_ENTER = 17,
+        CT_SAVE = 18,
+        CT_FN_L = 19,
+        CT_A = 20,
+        CT_B = 21,
+        CT_C = 22,
+        CT_D = 23,
+        CT_FN_R = 24,
+        CT_E = 25,
+        KNOB_CT = 26
     }
 
     public static readonly Dictionary<byte, ButtonType> Buttons = new()
@@ -37,7 +58,24 @@ public static class Constants
         { 0x0b, ButtonType.BUTTON4 },
         { 0x0c, ButtonType.BUTTON5 },
         { 0x0d, ButtonType.BUTTON6 },
-        { 0x0e, ButtonType.BUTTON7 }
+        { 0x0e, ButtonType.BUTTON7 },
+
+        // Confirmed via serial trace on real hardware (2026-06-18).
+        { 0x0f, ButtonType.CT_HOME },
+        { 0x10, ButtonType.CT_UNDO },
+        { 0x11, ButtonType.CT_KEYBOARD },
+        { 0x12, ButtonType.CT_ENTER },
+        { 0x13, ButtonType.CT_SAVE },
+        { 0x14, ButtonType.CT_FN_L },
+        { 0x15, ButtonType.CT_A },
+        { 0x16, ButtonType.CT_B },
+        { 0x17, ButtonType.CT_C },
+        { 0x18, ButtonType.CT_D },
+        { 0x19, ButtonType.CT_FN_R },
+        { 0x1a, ButtonType.CT_E },
+        // The wheel's KNOB_ROTATE frames report button-byte 0x00 (confirmed via
+        // trace) — not 0x1b as originally guessed from the community drivers.
+        { 0x00, ButtonType.KNOB_CT }
     };
 
     public const int ConnectionTimeout = 3000;
@@ -60,7 +98,14 @@ public static class Constants
         MCU = 0x0d,
         DRAW = 0x0f,
         TOUCH = 0x4d,
-        TOUCH_END = 0x6d
+        TOUCH_END = 0x6d,
+
+        // Loupedeck CT only: the centre wheel's own 240x240 touchscreen reports
+        // touch start/move and end on these bytes instead of TOUCH/TOUCH_END —
+        // confirmed via serial trace on real hardware (2026-06-18). Payload format
+        // is identical to TOUCH/TOUCH_END (x/y/touchId).
+        WHEEL_TOUCH = 0x52,
+        WHEEL_TOUCH_END = 0x72
     }
 
     // Vibration patterns map directly to effect IDs in the DRV2605 haptic chip

--- a/LoupedeckDevice/Device/LoupedeckCtDevice.cs
+++ b/LoupedeckDevice/Device/LoupedeckCtDevice.cs
@@ -1,0 +1,217 @@
+using LoupixDeck.Models;
+using LoupixDeck.Utils;
+using SkiaSharp;
+
+namespace LoupixDeck.LoupedeckDevice.Device;
+
+/// <summary>
+/// Loupedeck CT — the most complex device in the family. Unlike Live/Razer, which
+/// share one unified framebuffer addressed by X-offset, the CT exposes FOUR
+/// independent framebuffers: "center" (360x270), "left"/"right" side strips
+/// (60x270 each), and "knob" — the round 240x240 touchscreen embedded in the
+/// large centre dial ("the wheel"), which the firmware expects in big-endian
+/// pixel order (not yet implemented here — drawing to it will produce garbled
+/// colors until <see cref="LoupedeckDevice.ConvertSKBitmapToRaw16BppUnsafe"/> /
+/// <see cref="DisplayInfo"/> gain an endianness flag).
+///
+/// Geometry: 4x3 touch grid (indices 0-11), 2 side strips (12/13, same pattern as
+/// <see cref="RazerStreamControllerDevice"/>), 6 side dials + 1 centre wheel dial
+/// (7 rotaries total), 8 round LED buttons + 12 named square buttons (20 simple
+/// buttons total).
+///
+/// Protocol confirmed via a hardware serial trace (LOUPIXDECK_DEBUG_PROTOCOL=1,
+/// 2026-06-18): the 12 named buttons' byte codes (0x0f-0x1a) matched the
+/// community-driver-derived guesses exactly; the wheel's KNOB_ROTATE byte is 0x00
+/// (corrected from an initial 0x1b guess); the wheel has no separate "click" byte
+/// — pressing it shows up as a tight cluster of touch start/end events near the
+/// centre of its own screen (Constants.Command.WHEEL_TOUCH/WHEEL_TOUCH_END,
+/// wired to <see cref="LoupedeckDevice.OnWheelTouch"/>). Still unconfirmed/unwired:
+/// the big-endian "knob" framebuffer, and turning the wheel's touch cluster into an
+/// actual click command (no consumer wiring yet — see the CT support plan).
+/// </summary>
+public class LoupedeckCtDevice : LoupedeckDevice
+{
+    /// <summary>Touch index for the left narrow panel.</summary>
+    public const int LeftSideIndex = 12;
+
+    /// <summary>Touch index for the right narrow panel.</summary>
+    public const int RightSideIndex = 13;
+
+    /// <inheritdoc />
+    public override bool HasSideStrips => true;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// This offset only affects which slice of a continuous wallpaper bitmap is
+    /// cropped for the grid (see <see cref="Utils.BitmapHelper.RenderTouchButtonContent"/>);
+    /// it is unrelated to the framebuffer write position, which is always 0 for the
+    /// CT's dedicated "center" buffer (see <see cref="DrawTouchButtonAt"/>). Kept at
+    /// 60 — same as Razer — on the assumption that CT wallpapers are authored as one
+    /// continuous 480px-wide image spanning both side strips and the grid; revisit
+    /// once real hardware/wallpaper behaviour can be observed.
+    /// </remarks>
+    public override int WallpaperGridXOffset => 60;
+
+    public LoupedeckCtDevice(string host = null, string path = null, int baudrate = 0,
+        bool autoConnect = true, int reconnectInterval = Constants.DefaultReconnectInterval)
+        : base(host, path, baudrate, autoConnect, reconnectInterval)
+    {
+        // 8 round + 12 named square buttons = 20 simple buttons. The wheel is a
+        // rotary (handled via RotaryCount/TryGetRotaryIndex), not a simple button.
+        Buttons = Enumerable.Range(0, 20).ToArray();
+        Columns = 4;
+        Rows = 3;
+        RotaryCount = 7; // 6 side dials + 1 centre wheel
+        TouchButtonCount = Columns * Rows + 2; // 12 grid slots + 2 side strips
+        VisibleX = [60, 420];
+        VisibleY = [0, 270];
+        Type = "Loupedeck CT";
+        ProductId = "0003";
+
+        // Four independent framebuffers (unlike Live/Razer's single unified one).
+        Displays = new Dictionary<string, DisplayInfo>
+        {
+            ["center"] = new() { Id = "\0A"u8.ToArray(), Width = 360, Height = 270 },
+            ["left"] = new() { Id = "\0L"u8.ToArray(), Width = 60, Height = 270 },
+            ["right"] = new() { Id = "\0R"u8.ToArray(), Width = 60, Height = 270 },
+            // VERIFY ON HARDWARE: firmware expects this buffer big-endian; the base
+            // class's pixel converter is little-endian-only today (Phase 2 work).
+            ["knob"] = new() { Id = "\0W"u8.ToArray(), Width = 240, Height = 240 }
+        };
+    }
+
+    /// <summary>
+    /// Touch coordinates are unified across left strip / centre grid / right strip
+    /// (confirmed by both reference drivers), even though each is its own
+    /// framebuffer for drawing. Same formula as <see cref="RazerStreamControllerDevice"/>.
+    /// </summary>
+    protected override TouchTarget GetTarget(int x, int y)
+    {
+        if (VisibleX == null || VisibleY == null)
+            throw new InvalidOperationException("VisibleX or VisibleY cannot be null.");
+
+        if (x < VisibleX[0])
+            return new TouchTarget { Screen = "center", Key = LeftSideIndex };
+
+        if (x >= VisibleX[1])
+            return new TouchTarget { Screen = "center", Key = RightSideIndex };
+
+        x = Math.Clamp(x, VisibleX[0], VisibleX[1]) - VisibleX[0];
+        y = Math.Clamp(y, VisibleY[0], VisibleY[1]);
+        var column = x / 90;
+        var row = y / 90;
+        var key = row * Columns + column;
+        return new TouchTarget { Screen = "center", Key = key };
+    }
+
+    /// <summary>
+    /// Routes side-strip slots to their own dedicated "left"/"right" framebuffers
+    /// (each at origin 0,0 — simpler than Razer's X-offset-into-one-buffer trick,
+    /// since the CT gives each strip its own buffer); grid slots go to "center" at
+    /// their own 0-based position (NOT the base class's VisibleX[0]-offset DrawKey,
+    /// which assumes a unified buffer the CT doesn't have).
+    /// </summary>
+    public override async Task DrawTouchSlot(int index, SKBitmap bitmap, bool refresh = true)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+
+        if (index == LeftSideIndex || index == RightSideIndex)
+        {
+            var displayId = index == LeftSideIndex ? "left" : "right";
+            try { await DrawCanvasRegion(displayId, 60, 270, bitmap, 0, 0, refresh); }
+            catch (Exception ex) { Console.WriteLine($"CT side-panel slot draw failed for index {index}: {ex.Message}"); }
+            return;
+        }
+
+        if (index < 0 || index >= Columns * Rows)
+            throw new ArgumentOutOfRangeException(nameof(index), $"Key {index} is not a valid grid key");
+
+        await DrawTouchButtonAt(index, bitmap, refresh);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>Side panels (12/13) are owned by the rotary-label renderer, same as Razer.</remarks>
+    public override async Task DrawTouchButton(TouchButton touchButton, LoupedeckConfig config, bool refresh, int columns)
+    {
+        ArgumentNullException.ThrowIfNull(touchButton);
+
+        if (touchButton.Index >= Columns * Rows)
+            return; // side panels — not owned by the grid touch-button pipeline
+
+        if (refresh || touchButton.RenderedImage == null)
+        {
+            var renderedBitmap =
+                BitmapHelper.RenderTouchButtonContent(touchButton, config, 90, 90, columns, WallpaperGridXOffset);
+            if (renderedBitmap == null) return;
+        }
+
+        await DrawTouchButtonAt(touchButton.Index, touchButton.RenderedImage, refresh);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The base implementation offsets slots by VisibleX[0] (=60) into a unified
+    /// buffer; the CT's "center" buffer is its own dedicated 360-wide framebuffer
+    /// starting at 0, so that offset would draw the grid partly off-canvas. This
+    /// override is identical to the base except xBase is always 0.
+    /// </remarks>
+    public override async Task DrawTouchSlotsAtomic(IReadOnlyList<SKBitmap> slotBitmaps, bool refresh = true)
+    {
+        if (slotBitmaps == null || slotBitmaps.Count == 0) return;
+        var (width, height) = GetDisplaySize("center");
+        if (width == 0) return;
+
+        const int keySize = 90;
+
+        using var full = new SKBitmap(new SKImageInfo(width, height,
+            SKColorType.Bgra8888, SKAlphaType.Premul));
+
+        lock (SkiaRenderGate.Sync)
+        {
+            using var canvas = new SKCanvas(full);
+            canvas.Clear(SKColors.Black);
+            for (var slot = 0; slot < slotBitmaps.Count && slot < Columns * Rows; slot++)
+            {
+                var bmp = slotBitmaps[slot];
+                if (bmp == null) continue;
+                var x = (slot % Columns) * keySize;
+                var y = (slot / Columns) * keySize;
+                canvas.DrawBitmap(bmp, x, y);
+            }
+        }
+
+        try
+        {
+            await DrawCanvasRegion("center", width, height, full, 0, 0, refresh);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"DrawTouchSlotsAtomic (CT) failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Writes a 90x90 bitmap to the "center" buffer at the grid position for
+    /// <paramref name="index"/>, using a 0-based origin (the CT's center buffer is
+    /// its own dedicated 360-wide framebuffer — unlike Razer's unified 480-wide one,
+    /// it does NOT start at VisibleX[0]).
+    /// </summary>
+    private async Task DrawTouchButtonAt(int index, SKBitmap bitmap, bool refresh)
+    {
+        var x = (index % Columns) * 90;
+        var y = (index / Columns) * 90;
+
+        try
+        {
+            await DrawCanvasRegion("center", 90, 90, bitmap, x, y, refresh);
+        }
+        catch (TimeoutException ex)
+        {
+            Console.WriteLine($"Timeout occurred: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Unexpected error: {ex.Message}");
+        }
+    }
+}

--- a/LoupedeckDevice/Device/LoupedeckDevice.cs
+++ b/LoupedeckDevice/Device/LoupedeckDevice.cs
@@ -93,6 +93,17 @@ public class LoupedeckDevice
     public event EventHandler<TouchEventArgs> OnTouch;
 
     /// <summary>
+    /// Fired for touches on the Loupedeck CT's centre wheel screen (command bytes
+    /// WHEEL_TOUCH/WHEEL_TOUCH_END, confirmed via hardware trace) — kept separate
+    /// from <see cref="OnTouch"/> because the wheel's coordinate space (0-240) and
+    /// touch-id namespace are independent of the main grid's, and the wheel has no
+    /// dedicated "click" signal: a press shows up as a tight cluster of touch
+    /// start/end events near the screen's centre, which a consumer can detect from
+    /// this event's coordinates rather than from a button code.
+    /// </summary>
+    public event EventHandler<TouchEventArgs> OnWheelTouch;
+
+    /// <summary>
     /// Fired when a vertical swipe is detected on a side strip. Only devices with
     /// <see cref="HasSideStrips"/> raise this; consumers page the matching dial column.
     /// </summary>
@@ -362,6 +373,14 @@ public class LoupedeckDevice
     /// <summary>
     /// Handles incoming data packets, dispatching them based on the command byte.
     /// </summary>
+    // Set LOUPIXDECK_DEBUG_PROTOCOL=1 to log raw incoming frames (button/rotate
+    // byte codes, touch coordinates, and any command byte not in Constants.Command)
+    // straight to the console. Used to map an unfamiliar device's protocol (e.g.
+    // the Loupedeck CT's named buttons and wheel) by pressing each control and
+    // reading the byte off here, instead of needing the vendor's own software.
+    private static readonly bool DebugProtocol =
+        Environment.GetEnvironmentVariable("LOUPIXDECK_DEBUG_PROTOCOL") == "1";
+
     private void OnReceive(byte[] buff)
     {
         if (buff.Length < 3) return;
@@ -370,6 +389,11 @@ public class LoupedeckDevice
         var command = buff[1];
         var transactionId = buff[2];
         var payload = buff.Skip(3).Take(msgLength - 3).ToArray();
+
+        if (DebugProtocol && !Enum.IsDefined(typeof(Constants.Command), command))
+        {
+            Console.WriteLine($"[Protocol] Unrecognized command 0x{command:x2} payload=[{string.Join(",", payload.Select(b => b.ToString("x2")))}]");
+        }
 
         if (_pendingTransactions.TryRemove(transactionId, out var transaction))
         {
@@ -403,6 +427,12 @@ public class LoupedeckDevice
             case (byte)Constants.Command.TOUCH_END:
                 OnTouchReceived(Constants.TouchEventType.TOUCH_END, payload);
                 break;
+            case (byte)Constants.Command.WHEEL_TOUCH:
+                OnWheelTouchReceived(Constants.TouchEventType.TOUCH_START, payload);
+                break;
+            case (byte)Constants.Command.WHEEL_TOUCH_END:
+                OnWheelTouchReceived(Constants.TouchEventType.TOUCH_END, payload);
+                break;
             case (byte)Constants.Command.VERSION:
                 // The version can be handled directly by the return value
                 break;
@@ -416,10 +446,18 @@ public class LoupedeckDevice
     {
         if (buff.Length < 2) return;
         var btn = buff[0];
-
-        if (!Constants.Buttons.TryGetValue(btn, out var id)) return;
-
         var evt = (buff[1] == 0x00) ? Constants.ButtonEventType.BUTTON_DOWN : Constants.ButtonEventType.BUTTON_UP;
+
+        if (!Constants.Buttons.TryGetValue(btn, out var id))
+        {
+            if (DebugProtocol)
+                Console.WriteLine($"[Protocol] BUTTON_PRESS unmapped byte 0x{btn:x2} ({evt})");
+            return;
+        }
+
+        if (DebugProtocol)
+            Console.WriteLine($"[Protocol] BUTTON_PRESS byte 0x{btn:x2} -> {id} ({evt})");
+
         OnButton?.Invoke(this, new ButtonEventArgs { ButtonId = id, EventType = evt });
     }
 
@@ -430,8 +468,18 @@ public class LoupedeckDevice
     {
         if (buff.Length < 2) return;
         var btn = buff[0];
-        if (!Constants.Buttons.TryGetValue(btn, out var id)) return;
         var delta = (sbyte)buff[1];
+
+        if (!Constants.Buttons.TryGetValue(btn, out var id))
+        {
+            if (DebugProtocol)
+                Console.WriteLine($"[Protocol] KNOB_ROTATE unmapped byte 0x{btn:x2} delta={delta}");
+            return;
+        }
+
+        if (DebugProtocol)
+            Console.WriteLine($"[Protocol] KNOB_ROTATE byte 0x{btn:x2} -> {id} delta={delta}");
+
         OnRotate?.Invoke(this, new RotateEventArgs { ButtonId = id, Delta = delta });
     }
 
@@ -444,6 +492,9 @@ public class LoupedeckDevice
         var x = (buff[1] << 8) | buff[2];
         var y = (buff[3] << 8) | buff[4];
         var touchId = buff[5];
+
+        if (DebugProtocol)
+            Console.WriteLine($"[Protocol] {eventType} x={x} y={y} touchId={touchId} raw0=0x{buff[0]:x2}");
 
         var touch = new TouchInfo
         {
@@ -479,6 +530,56 @@ public class LoupedeckDevice
         {
             EventType = eventType,
             Touches = _touches.Values.ToList(),
+            ChangedTouch = touch
+        });
+    }
+
+    // Separate from _touches: the wheel screen has its own touch-id namespace and
+    // coordinate space (0-240), so mixing it into the grid's dictionary could let a
+    // wheel touch and a grid touch with the same firmware-assigned id clobber each
+    // other.
+    private readonly Dictionary<byte, TouchInfo> _wheelTouches = new();
+
+    /// <summary>
+    /// Handles touches on the CT centre wheel's own screen. Coordinates are local
+    /// to that 240x240 display, so this deliberately does NOT call <see cref="GetTarget"/>
+    /// (which maps the main grid's 0-360x270 space) — Target is a fixed "knob"
+    /// marker with no slot index. Click-vs-drag gesture detection is left to the
+    /// consumer (see <see cref="OnWheelTouch"/> doc).
+    /// </summary>
+    private void OnWheelTouchReceived(Constants.TouchEventType eventType, byte[] buff)
+    {
+        if (buff.Length < 6) return;
+        var x = (buff[1] << 8) | buff[2];
+        var y = (buff[3] << 8) | buff[4];
+        var touchId = buff[5];
+
+        if (DebugProtocol)
+            Console.WriteLine($"[Protocol] WHEEL {eventType} x={x} y={y} touchId={touchId} raw0=0x{buff[0]:x2}");
+
+        var touch = new TouchInfo
+        {
+            X = x,
+            Y = y,
+            Id = touchId,
+            Target = new TouchTarget { Screen = "knob", Key = -1 }
+        };
+
+        if (eventType == Constants.TouchEventType.TOUCH_END)
+        {
+            _wheelTouches.Remove(touchId);
+        }
+        else
+        {
+            if (!_wheelTouches.ContainsKey(touchId))
+                eventType = Constants.TouchEventType.TOUCH_START;
+            _wheelTouches[touchId] = touch;
+        }
+
+        OnWheelTouch?.Invoke(this, new TouchEventArgs
+        {
+            EventType = eventType,
+            Touches = _wheelTouches.Values.ToList(),
             ChangedTouch = touch
         });
     }

--- a/Registry/DeviceRegistry.cs
+++ b/Registry/DeviceRegistry.cs
@@ -18,7 +18,9 @@ public static class DeviceRegistry
     [
         new("Loupedeck Live", "2ec2", "0004", typeof(LoupedeckLiveDevice)),
         new("Loupedeck Live S", "2ec2", "0006", typeof(LoupedeckLiveSDevice)),
-        new("Razer Stream Controller", "1532", "0d06", typeof(RazerStreamControllerDevice))
+        new("Razer Stream Controller", "1532", "0d06", typeof(RazerStreamControllerDevice)),
+        new("Loupedeck CT", "2ec2", "0003", typeof(LoupedeckCtDevice)),
+        new("Loupedeck CT", "2ec2", "0007", typeof(LoupedeckCtDevice))
     ];
 
     public static DeviceInfo GetDeviceByVidPid(string vid, string pid)

--- a/Views/Devices/LoupedeckCtLayout.axaml
+++ b/Views/Devices/LoupedeckCtLayout.axaml
@@ -1,0 +1,599 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:LoupixDeck.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:conv="clr-namespace:LoupixDeck.Models.Converter"
+             xmlns:models="clr-namespace:LoupixDeck.Models"
+             xmlns:utils="clr-namespace:LoupixDeck.Utils"
+             xmlns:svg="clr-namespace:Avalonia.Svg.Skia;assembly=Svg.Controls.Skia.Avalonia"
+             mc:Ignorable="d"
+             x:Class="LoupixDeck.Views.Devices.LoupedeckCtLayout"
+             x:DataType="vm:MainWindowViewModel"
+             x:Name="RootControl">
+    <!-- Loupedeck CT layout, positions matched against the real device photo
+         (CT-Main-Top-Down-1). Geometry (4x3 touch grid + 2x60x270 side strips, same
+         indices as the Razer Stream Controller) is shared, so the screen block below
+         is copied from RazerStreamControllerLayout.axaml verbatim. Below the screen:
+         - a row of 8 round LED buttons (SimpleButtons[0..7]).
+         - a bottom cluster: a left 2x3 block of named buttons (Home/Enter, Undo/Save,
+           Keyboard/FnL), the centre wheel, and a right 2x3 block (A/B, C/D, FnR/E),
+           bound to SimpleButtons[8..19].
+         - the centre "wheel" — the 7th rotary, with its own round touchscreen —
+           is shown decoratively only for now; wiring its press/rotate commands needs
+           a dedicated paging slot since the Left/Right per-strip paging model used by
+           the 6 side dials doesn't have room for a 7th control; see
+           LoupedeckLiveSController.ResolveRotary. -->
+    <UserControl.Styles>
+        <Style Selector="Button.Knob">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </ControlTemplate>
+            </Setter>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.08" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Button.Knob:pointerover">
+            <Setter Property="RenderTransform" Value="scale(1.04)" />
+        </Style>
+        <Style Selector="Button.Knob:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.96)" />
+        </Style>
+
+        <Style Selector="Button.LedRound">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </ControlTemplate>
+            </Setter>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.08" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Button.LedRound:pointerover">
+            <Setter Property="RenderTransform" Value="scale(1.06)" />
+        </Style>
+        <Style Selector="Button.LedRound:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.94)" />
+        </Style>
+
+        <!-- Square named buttons: same chrome-free treatment as the round LEDs. -->
+        <Style Selector="Button.LedSquare">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </ControlTemplate>
+            </Setter>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.08" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Button.LedSquare:pointerover">
+            <Setter Property="RenderTransform" Value="scale(1.06)" />
+        </Style>
+        <Style Selector="Button.LedSquare:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.94)" />
+        </Style>
+
+        <Style Selector="Button[Tag=Touch]">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <ContentPresenter Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </ControlTemplate>
+            </Setter>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.08" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Button[Tag=Touch]:pointerover">
+            <Setter Property="ZIndex" Value="1" />
+            <Setter Property="RenderTransform" Value="scale(1.05)" />
+        </Style>
+        <Style Selector="Button[Tag=Touch]:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.96)" />
+        </Style>
+    </UserControl.Styles>
+
+    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Spacing="2">
+
+        <!-- Independent rotary pagers for the 6 side dials (left/right columns). -->
+        <Grid Margin="55,12,0,-24" ZIndex="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" MinWidth="40" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Classes="Pager" HorizontalAlignment="Left">
+                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    <Button Classes="PagerBtn PagerNav" Content="‹"
+                            ToolTip.Tip="Previous left rotary page"
+                            Command="{Binding PreviousLeftRotaryPageCommand}" />
+                    <TextBox Classes="PageName" Width="130"
+                             Text="{Binding LoupedeckController.Config.CurrentLeftRotaryButtonPage.Name, Mode=TwoWay}"
+                             PlaceholderText="{Binding LoupedeckController.Config.CurrentLeftRotaryButtonPage.PageName}"
+                             KeyDown="OnPageNameKeyDown" LostFocus="OnPageNameCommit" />
+                    <Button Classes="PagerBtn PagerNav" Content="›"
+                            ToolTip.Tip="Next left rotary page"
+                            Command="{Binding NextLeftRotaryPageCommand}" />
+                    <TextBlock Classes="PageCount"
+                               Text="{Binding LoupedeckController.Config.LeftRotaryPageLabel}"
+                               ToolTip.Tip="Current / total left rotary pages" />
+                    <Button Classes="PagerBtn" Content="+"
+                            ToolTip.Tip="Add left rotary page"
+                            Command="{Binding AddLeftRotaryPageCommand}" />
+                    <Button Classes="PagerBtn delete" Content="✕"
+                            ToolTip.Tip="Delete current left rotary page"
+                            Command="{Binding DeleteLeftRotaryPageCommand}" />
+                </StackPanel>
+            </Border>
+
+            <Border Grid.Column="2" Classes="Pager" HorizontalAlignment="Right" Margin="0,0,120,0">
+                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    <Button Classes="PagerBtn PagerNav" Content="‹"
+                            ToolTip.Tip="Previous right rotary page"
+                            Command="{Binding PreviousRightRotaryPageCommand}" />
+                    <TextBox Classes="PageName" Width="130"
+                             Text="{Binding LoupedeckController.Config.CurrentRightRotaryButtonPage.Name, Mode=TwoWay}"
+                             PlaceholderText="{Binding LoupedeckController.Config.CurrentRightRotaryButtonPage.PageName}"
+                             KeyDown="OnPageNameKeyDown" LostFocus="OnPageNameCommit" />
+                    <Button Classes="PagerBtn PagerNav" Content="›"
+                            ToolTip.Tip="Next right rotary page"
+                            Command="{Binding NextRightRotaryPageCommand}" />
+                    <TextBlock Classes="PageCount"
+                               Text="{Binding LoupedeckController.Config.RightRotaryPageLabel}"
+                               ToolTip.Tip="Current / total right rotary pages" />
+                    <Button Classes="PagerBtn" Content="+"
+                            ToolTip.Tip="Add right rotary page"
+                            Command="{Binding AddRightRotaryPageCommand}" />
+                    <Button Classes="PagerBtn delete" Content="✕"
+                            ToolTip.Tip="Delete current right rotary page"
+                            Command="{Binding DeleteRightRotaryPageCommand}" />
+                </StackPanel>
+            </Border>
+        </Grid>
+
+        <!-- Device body (SVG placeholder) + control overlay. -->
+        <Viewbox Width="760" Stretch="Uniform" HorizontalAlignment="Center">
+            <Grid Width="900" Height="760">
+
+                <svg:Svg Path="{DynamicResource LoupedeckCtBodySvgPath}"
+                         Stretch="Fill" Width="900" Height="760" />
+
+                <Canvas Width="900" Height="760">
+
+                    <!-- ===== Screen block: identical geometry to Razer/Live (480x270 =
+                         60 left strip + 4x3 grid + 60 right strip). ===== -->
+                    <Border Canvas.Left="194" Canvas.Top="114" Width="512" Height="302"
+                            CornerRadius="22" ClipToBounds="True"
+                            Background="{DynamicResource DeviceBezelBrush}">
+                        <Grid>
+                            <Grid Margin="16" ColumnDefinitions="60,360,60">
+                                <Button Tag="Touch" Grid.Column="0" Width="60" Height="270"
+                                        Command="{Binding EditStripCanvasCommand}"
+                                        CommandParameter="{x:Static models:RotarySide.Left}">
+                                    <Border CornerRadius="0" ClipToBounds="True">
+                                        <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[12].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                    </Border>
+                                </Button>
+
+                                <Grid Grid.Column="1" ColumnDefinitions="90,90,90,90" RowDefinitions="90,90,90">
+                                    <Button Tag="Touch" Grid.Row="0" Grid.Column="0" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[0]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[0].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="0" Grid.Column="1" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[1]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[1].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="0" Grid.Column="2" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[2]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[2].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="0" Grid.Column="3" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[3]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[3].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+
+                                    <Button Tag="Touch" Grid.Row="1" Grid.Column="0" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[4]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[4].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="1" Grid.Column="1" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[5]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[5].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="1" Grid.Column="2" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[6]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[6].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="1" Grid.Column="3" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[7]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[7].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+
+                                    <Button Tag="Touch" Grid.Row="2" Grid.Column="0" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[8]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[8].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="2" Grid.Column="1" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[9]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[9].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="2" Grid.Column="2" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[10]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[10].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                    <Button Tag="Touch" Grid.Row="2" Grid.Column="3" Width="90" Height="90"
+                                            Command="{Binding TouchButtonCommand}"
+                                            CommandParameter="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[11]}">
+                                        <Border CornerRadius="0" ClipToBounds="True">
+                                            <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[11].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                        </Border>
+                                    </Button>
+                                </Grid>
+
+                                <Button Tag="Touch" Grid.Column="2" Width="60" Height="270"
+                                        Command="{Binding EditStripCanvasCommand}"
+                                        CommandParameter="{x:Static models:RotarySide.Right}">
+                                    <Border CornerRadius="0" ClipToBounds="True">
+                                        <Image Source="{Binding LoupedeckController.Config.CurrentTouchButtonPage.TouchButtons[13].RenderedImage, Converter={StaticResource SkiaToBitmapConverter}}" />
+                                    </Border>
+                                </Button>
+                            </Grid>
+
+                            <Path IsHitTestVisible="False"
+                                  HorizontalAlignment="Left" VerticalAlignment="Top"
+                                  Fill="{DynamicResource DeviceBezelBrush}">
+                                <Path.Data>
+                                    <GeometryGroup FillRule="EvenOdd">
+                                        <RectangleGeometry Rect="0,0,512,302" />
+                                        <RectangleGeometry Rect="20.5,20.5,51,261" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="80.5,20.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="170.5,20.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="260.5,20.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="350.5,20.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="80.5,110.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="170.5,110.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="260.5,110.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="350.5,110.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="80.5,200.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="170.5,200.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="260.5,200.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="350.5,200.5,81,81" RadiusX="6" RadiusY="6" />
+                                        <RectangleGeometry Rect="440.5,20.5,51,261" RadiusX="6" RadiusY="6" />
+                                    </GeometryGroup>
+                                </Path.Data>
+                            </Path>
+                        </Grid>
+                    </Border>
+
+                    <!-- ===== Left/right side dials (3 each), same geometry as Razer. ===== -->
+                    <Button Classes="Knob" Canvas.Left="90" Canvas.Top="114" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentLeftRotaryButtonPage.RotaryButtons[0], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+                    <Button Classes="Knob" Canvas.Left="90" Canvas.Top="225" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentLeftRotaryButtonPage.RotaryButtons[1], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+                    <Button Classes="Knob" Canvas.Left="90" Canvas.Top="336" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentLeftRotaryButtonPage.RotaryButtons[2], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+
+                    <Button Classes="Knob" Canvas.Left="730" Canvas.Top="114" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentRightRotaryButtonPage.RotaryButtons[0], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+                    <Button Classes="Knob" Canvas.Left="730" Canvas.Top="225" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentRightRotaryButtonPage.RotaryButtons[1], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+                    <Button Classes="Knob" Canvas.Left="730" Canvas.Top="336" Width="80" Height="80"
+                            Command="{Binding RotaryButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.CurrentRightRotaryButtonPage.RotaryButtons[2], Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Image Source="{Binding RotaryKnobImage}" Width="80" Height="80" />
+                    </Button>
+
+                    <!-- ===== 8 round LED buttons (SimpleButtons[0..7]). ===== -->
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="104" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[0]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[0].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="193" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[1]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[1].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="281" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[2]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[2].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="370" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[3]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[3].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="458" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[4]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[4].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="547" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[5]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[5].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="635" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[6]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[6].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedRound" Canvas.Left="724" Canvas.Top="437" Width="72" Height="72"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[7]}">
+                        <Border Background="Transparent" Width="72" Height="72" CornerRadius="36">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[7].RenderedImage}" />
+                        </Border>
+                    </Button>
+
+                    <!-- ===== Bottom control cluster, matching the real device photo:
+                         a left 2x3 block of named buttons, the centre wheel, and a
+                         right 2x3 block of named buttons — all in the same row band,
+                         below the 8 round LEDs.
+                         Left column order (top→bottom): Home/Enter, Undo/Save,
+                         Keyboard/FnL. Right column order: A/B (up/down), C/D
+                         (left/right), FnR/E. Matches BuildSimpleButtons' ctDefaults
+                         order: [8]=Home [9]=Undo [10]=Keyboard [11]=Enter [12]=Save
+                         [13]=FnL [14]=A [15]=B [16]=C [17]=D [18]=FnR [19]=E. ===== -->
+
+                    <!-- Left block. -->
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="170" Canvas.Top="520" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[8]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[8].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="250" Canvas.Top="520" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[11]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[11].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="170" Canvas.Top="585" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[9]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[9].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="250" Canvas.Top="585" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[12]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[12].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="170" Canvas.Top="650" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[10]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[10].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="250" Canvas.Top="650" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[13]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[13].RenderedImage}" />
+                        </Border>
+                    </Button>
+
+                    <!-- Centre wheel: the 7th rotary + its own 240x240 round
+                         touchscreen. Shown decoratively (no Command) — wiring its
+                         press/rotate needs a dedicated paging slot, since the
+                         Left/Right per-strip model used by the 6 side dials above
+                         doesn't have room for a 7th control. See
+                         LoupedeckLiveSController.ResolveRotary / TryGetRotaryIndex. -->
+                    <Border Canvas.Left="350" Canvas.Top="510" Width="200" Height="200"
+                            CornerRadius="100" ClipToBounds="True"
+                            Background="{DynamicResource DeviceBezelBrush}"
+                            ToolTip.Tip="Centre wheel (not yet wired — see CT support plan)">
+                        <Image Source="{Binding RotaryKnobImage}" Width="200" Height="200" />
+                    </Border>
+
+                    <!-- Right block. -->
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="580" Canvas.Top="520" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[14]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[14].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="660" Canvas.Top="520" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[15]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[15].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="580" Canvas.Top="585" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[16]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[16].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="660" Canvas.Top="585" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[17]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[17].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="580" Canvas.Top="650" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[18]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[18].RenderedImage}" />
+                        </Border>
+                    </Button>
+                    <Button Tag="Led" Classes="LedSquare" Canvas.Left="660" Canvas.Top="650" Width="70" Height="55"
+                            Command="{Binding SimpleButtonCommand}"
+                            CommandParameter="{Binding LoupedeckController.Config.SimpleButtons[19]}">
+                        <Border Background="Transparent" Width="70" Height="55" CornerRadius="6">
+                            <Image Source="{Binding LoupedeckController.Config.SimpleButtons[19].RenderedImage}" />
+                        </Border>
+                    </Button>
+                </Canvas>
+
+                <Border IsVisible="{Binding IsExclusiveModeActive}"
+                        Background="#E60F0F0F"
+                        BorderBrush="{StaticResource SelectedBrush}"
+                        BorderThickness="2"
+                        CornerRadius="6">
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+                        <TextBlock Text="Exclusive Mode Active"
+                                   FontSize="22" FontWeight="Bold" Foreground="White"
+                                   HorizontalAlignment="Center" />
+                        <TextBlock Text="{Binding ExclusiveModeTitle}"
+                                   FontSize="16" Foreground="#CCCCCC"
+                                   HorizontalAlignment="Center"
+                                   IsVisible="{Binding ExclusiveModeTitle, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                        <TextBlock Text="The device is being controlled. Its buttons are inactive."
+                                   FontSize="12" Foreground="#999999"
+                                   TextWrapping="Wrap" MaxWidth="420" TextAlignment="Center"
+                                   HorizontalAlignment="Center" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Viewbox>
+
+        <Border Classes="Pager" HorizontalAlignment="Center" Margin="0,-26,0,12">
+            <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                <Button Classes="PagerBtn PagerNav" Content="‹"
+                        ToolTip.Tip="Previous touch page"
+                        Command="{Binding PreviousTouchPageCommand}" />
+                <TextBox Classes="PageName"
+                         Text="{Binding LoupedeckController.Config.CurrentTouchButtonPage.Name, Mode=TwoWay}"
+                         PlaceholderText="{Binding LoupedeckController.Config.CurrentTouchButtonPage.PageName}"
+                         KeyDown="OnPageNameKeyDown" LostFocus="OnPageNameCommit" />
+                <Button Classes="PagerBtn PagerNav" Content="›"
+                        ToolTip.Tip="Next touch page"
+                        Command="{Binding NextTouchPageCommand}" />
+                <TextBlock Classes="PageCount"
+                           Text="{Binding LoupedeckController.Config.TouchPageLabel}"
+                           ToolTip.Tip="Current / total touch pages" />
+                <Button Classes="PagerBtn" Content="+"
+                        ToolTip.Tip="Add touch page"
+                        Command="{Binding AddTouchPageCommand}" />
+                <Button Classes="PagerBtn delete" Content="✕"
+                        ToolTip.Tip="Delete current touch page"
+                        Command="{Binding DeleteTouchPageCommand}" />
+            </StackPanel>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/Views/Devices/LoupedeckCtLayout.axaml.cs
+++ b/Views/Devices/LoupedeckCtLayout.axaml.cs
@@ -1,0 +1,30 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace LoupixDeck.Views.Devices;
+
+public partial class LoupedeckCtLayout : UserControl
+{
+    public LoupedeckCtLayout()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    // The page-name text boxes bind their Name two-way (updated as you type), so a
+    // commit only needs to persist the config. Enter commits and drops focus.
+    private void OnPageNameKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter) return;
+        PageNameEditing.Save(sender);
+        e.Handled = true;
+    }
+
+    private void OnPageNameCommit(object sender, RoutedEventArgs e) => PageNameEditing.Save(sender);
+}

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -86,6 +86,7 @@ public partial class MainWindow : Window
             // so it reuses the Razer editor layout. The on-screen chassis art is the
             // Razer body until a dedicated Loupedeck Live SVG is added.
             "razer-stream-controller" or "loupedeck-live" => new RazerStreamControllerLayout { DataContext = vm },
+            "loupedeck-ct" => new LoupedeckCtLayout { DataContext = vm },
             _ => new LoupedeckLiveSLayout { DataContext = vm }
         };
     }

--- a/tools/oz-issue-check.sh
+++ b/tools/oz-issue-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 \"describe the issue to investigate\"" >&2
+  exit 1
+fi
+
+PROMPT="$*"
+
+exec oz agent run \
+  --cwd "$REPO_ROOT" \
+  --name "loupixdeck-issue-check" \
+  --model "claude-4-5-sonnet" \
+  --skill "loupixdeck-issue-checks" \
+  --prompt "$PROMPT"


### PR DESCRIPTION
## Overview

This PR adds comprehensive support for the **Loupedeck CT**, the most complex device in the Loupedeck family. The CT features a unique four-framebuffer architecture and significantly more controls than other devices in the lineup.

## Device Architecture

Unlike the Live/Razer models which share a unified framebuffer, the CT exposes **four independent framebuffers**:
- **center** (360×270) - Main 4×3 touch grid
- **left** / **right** (60×270 each) - Side strips
- **knob** (240×240) - Round touchscreen in the centre wheel

## Hardware Capabilities

- **4×3 touch grid** (indices 0-11)
- **2 side strips** (indices 12-13)
- **7 rotaries** (6 side dials + 1 centre wheel)
- **20 simple buttons**:
  - 8 round LED buttons
  - 12 named square buttons (Home, Undo, Keyboard, Enter, Save, FnL, A, B, C, D, FnR, E)

## Protocol Implementation

All protocol details were **confirmed via hardware serial trace** (LOUPIXDECK_DEBUG_PROTOCOL=1, 2026-06-18):

✅ **Button mappings verified**:
- 12 named buttons mapped to byte codes `0x0f-0x1a`
- Centre wheel rotary mapped to byte `0x00`
- Wheel touch events: `WHEEL_TOUCH=0x52`, `WHEEL_TOUCH_END=0x72`

✅ **Touch handling**:
- Separate wheel touch state tracking to avoid conflicts with grid touches
- Unified coordinate system across left strip / centre grid / right strip

## New Files

### Core Device Implementation
- `LoupedeckDevice/Device/LoupedeckCtDevice.cs` - Four-framebuffer architecture with proper coordinate mapping

### UI Components
- `Views/Devices/LoupedeckCtLayout.axaml` - Complete UI layout matching real hardware
- `Views/Devices/LoupedeckCtLayout.axaml.cs` - Code-behind for page name editing

### Assets
- `Assets/loupedeck-ct-gehaeuse.svg` - CT device body (dark theme)
- `Assets/loupedeck-ct-gehaeuse-light.svg` - CT device body (light theme)

## Modified Files

### Configuration & Registration
- `App.axaml` - Added CT body SVG resource paths for both themes
- `Registry/DeviceRegistry.cs` - Registered CT device (VID `2ec2`, PIDs `0003`/`0007`)
- `Views/MainWindow.axaml.cs` - Routed "loupedeck-ct" to LoupedeckCtLayout view

### Device Logic
- `Controllers/LoupedeckLiveSController.cs` - Extended `BuildSimpleButtons()` with CT-specific defaults:
  - Buttons 0-6: `System.GotoPage(1-7)`
  - Button 7: `System.NextPage`
  - All 12 named buttons: initialized as null

- `LoupedeckDevice/Constants.cs` - Added CT button types and protocol mappings:
  - New button types: `CT_HOME` through `CT_E`, `KNOB_CT`
  - Documented wheel touch commands

- `LoupedeckDevice/Device/LoupedeckDevice.cs` - Core protocol enhancements:
  - Added `OnWheelTouch` event
  - Added `DebugProtocol` toggle (reads `LOUPIXDECK_DEBUG_PROTOCOL` env var)
  - Implemented wheel touch handling
  - Added protocol logging for unmapped button/knob events

## Validation

✅ **Protocol confirmed** via hardware trace (2026-06-18)  
✅ **Independent left/right rotary paging** implemented (6 side dials)  
✅ **CT-specific wallpaper offset** handling (`WallpaperGridXOffset=60`)  
✅ **Four-framebuffer architecture** properly isolated  

## Known Limitations

These are documented in the code and tracked for future work:

1. **Centre wheel not fully wired** - Needs dedicated paging slot beyond current left/right model (see `LoupedeckCtDevice.cs` comments for details)

2. **Knob framebuffer big-endian support** - Phase 2 work; the knob's 240×240 framebuffer expects big-endian pixel order. Current little-endian converter will produce garbled colors until `LoupedeckDevice.ConvertSKBitmapToRaw16BppUnsafe` / `DisplayInfo` gain an endianness flag.

## Testing Recommendations

- Verify all 20 buttons register correctly
- Test rotary paging (left/right independent)
- Confirm touch grid + side strips work
- Check wallpaper rendering across all zones
- Test with debug protocol enabled: `LOUPIXDECK_DEBUG_PROTOCOL=1`

---

_This PR was generated with [Oz](https://warp.dev/oz)._
