### PR TITLE
Add central animation scheduler foundation (#119)

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -249,6 +249,7 @@ public partial class App : Application
         catch (Exception ex) { Console.WriteLine($"[HotPlug] controller shutdown failed: {ex.Message}"); }
 
         (host.Provider.GetService(typeof(IDynamicTextManager)) as IDisposable)?.Dispose();
+        (host.Provider.GetService(typeof(Services.Animation.IAnimationScheduler)) as IDisposable)?.Dispose();
 
         var vm = _shell.Devices.FirstOrDefault(v =>
             string.Equals(v.ScopeKey, host.Device.ScopeKey, StringComparison.OrdinalIgnoreCase));

--- a/Controllers/LoupedeckLiveSController.cs
+++ b/Controllers/LoupedeckLiveSController.cs
@@ -33,6 +33,7 @@ public partial class LoupedeckLiveSController(
     ISideStripProviderRegistry sideStripRegistry,
     IAssetService assetService,
     INativeHapticService nativeHapticService,
+    Services.Animation.IAnimationScheduler animationScheduler,
     LoupedeckConfig config,
     DeviceRegistry.DeviceInfo deviceInfo,
     ResolvedDevice resolved,
@@ -153,6 +154,9 @@ public partial class LoupedeckLiveSController(
 
         // Stop plugin strips so their timers don't keep churning against a dead device.
         try { DetachAllSideStripProviders(); } catch { /* best effort */ }
+
+        // Halt the central animation loop so no frame is pushed to the gone device.
+        try { animationScheduler.Stop(); } catch { /* best effort */ }
 
         var device = deviceService.Device;
         if (device != null)

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -223,6 +223,11 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton<IPluginInstaller, PluginInstaller>();
         collection.AddSingleton<IPluginReloadService, PluginReloadService>();
 
+        // One central animation loop per device (issue #119): every animated feature
+        // registers here instead of owning its own timer, so the device has a single,
+        // globally rate-limitable render cadence that pauses for inactive pages.
+        collection.AddSingleton<Services.Animation.IAnimationScheduler, Services.Animation.AnimationScheduler>();
+
         collection.AddSingleton<IDynamicTextManager, DynamicTextManager>();
         collection.AddSingleton<IFolderNavigationService, FolderNavigationService>();
         collection.AddSingleton<IExclusiveModeService, ExclusiveModeService>();

--- a/Services/Animation/AnimationRenderContext.cs
+++ b/Services/Animation/AnimationRenderContext.cs
@@ -1,0 +1,42 @@
+namespace LoupixDeck.Services.Animation;
+
+/// <summary>
+/// Per-frame timing snapshot handed to an <see cref="IAnimationSource"/> when the
+/// central scheduler ticks it. All times are measured against a single shared
+/// high-resolution clock so every animation on the device sees a consistent timebase.
+/// </summary>
+public readonly struct AnimationRenderContext
+{
+    public AnimationRenderContext(
+        long frameNumber,
+        TimeSpan elapsed,
+        TimeSpan delta,
+        int effectiveFps,
+        CancellationToken cancellationToken)
+    {
+        FrameNumber = frameNumber;
+        Elapsed = elapsed;
+        Delta = delta;
+        EffectiveFps = effectiveFps;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>Zero-based frame counter for this source since it was registered.</summary>
+    public long FrameNumber { get; }
+
+    /// <summary>Total time the source has been registered and ticking.</summary>
+    public TimeSpan Elapsed { get; }
+
+    /// <summary>Wall-clock time since this source's previous frame (the first frame
+    /// reports the time since registration).</summary>
+    public TimeSpan Delta { get; }
+
+    /// <summary>The frame rate the scheduler is actually driving this source at,
+    /// after clamping the source's <see cref="IAnimationSource.TargetFps"/> to the
+    /// global limit. Useful for sources that pace their own interpolation.</summary>
+    public int EffectiveFps { get; }
+
+    /// <summary>Cancelled when the scheduler stops or the source is unregistered.
+    /// A long-running render should observe this to bail out promptly.</summary>
+    public CancellationToken CancellationToken { get; }
+}

--- a/Services/Animation/AnimationScheduler.cs
+++ b/Services/Animation/AnimationScheduler.cs
@@ -1,0 +1,339 @@
+using System.Diagnostics;
+
+namespace LoupixDeck.Services.Animation;
+
+/// <summary>
+/// Per-device central animation loop (issue #119). A single background task paces every
+/// registered <see cref="IAnimationSource"/>:
+///
+/// <list type="bullet">
+///   <item>one shared high-resolution clock (<see cref="Stopwatch"/>) drives all sources,
+///         so their timing never drifts apart;</item>
+///   <item>each source is ticked at its own <see cref="IAnimationSource.TargetFps"/>,
+///         clamped to <see cref="GlobalFpsLimit"/>;</item>
+///   <item>inactive sources (<see cref="IAnimationSource.IsActive"/> == false) are not
+///         ticked — pausing animations for non-current pages costs nothing;</item>
+///   <item>a source whose previous frame is still rendering is skipped rather than queued,
+///         so a slow render lowers that source's rate instead of piling work up;</item>
+///   <item>the loop parks (no busy-spin) when nothing is due and is woken by
+///         <see cref="Register"/> / <see cref="RequestFrame"/> / a completed frame.</item>
+/// </list>
+///
+/// Sources own their render targets and their dirty-state; the scheduler only owns timing.
+/// Render callbacks run off the UI thread (Skia work still goes through
+/// <see cref="LoupixDeck.Utils.SkiaRenderGate.Sync"/>, UI mutations are posted), matching the
+/// rest of the device pipeline.
+/// </summary>
+public sealed class AnimationScheduler : IAnimationScheduler, IDisposable
+{
+    private const int DefaultGlobalFpsLimit = 30;
+    private const int MaxGlobalFpsLimit = 120;
+
+    // While at least one source is registered the loop parks at most this long even when
+    // nothing is due, so an IsActive flip that wasn't pushed via RequestFrame is still
+    // noticed promptly. Cheap insurance — real activations should call RequestFrame.
+    private static readonly TimeSpan IdlePoll = TimeSpan.FromMilliseconds(250);
+
+    // Never sleep shorter than this; protects against a runaway tight loop if a source
+    // ever reports an absurdly high TargetFps.
+    private static readonly TimeSpan MinSleep = TimeSpan.FromMilliseconds(1);
+
+    private sealed class Registration(IAnimationSource source)
+    {
+        public IAnimationSource Source { get; } = source;
+        public long StartTimestamp { get; set; }
+        public long LastFrameTimestamp { get; set; }
+        public TimeSpan NextDue { get; set; }
+        public long FrameNumber { get; set; }
+
+        // 0 = idle, 1 = a frame is currently rendering. Guards against re-entrant ticks.
+        public int InFlight;
+    }
+
+    private readonly object _gate = new();
+    private readonly List<Registration> _registrations = [];
+    private readonly SemaphoreSlim _wake = new(0, 1);
+
+    private long _schedulerStart;
+    private int _globalFpsLimit = DefaultGlobalFpsLimit;
+    private CancellationTokenSource _cts;
+    private Task _loopTask;
+    private bool _disposed;
+
+    public int GlobalFpsLimit => Volatile.Read(ref _globalFpsLimit);
+
+    public void Register(IAnimationSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        lock (_gate)
+        {
+            if (_disposed) return;
+            if (_registrations.Any(r => ReferenceEquals(r.Source, source)))
+                return;
+
+            var now = ElapsedNow();
+            _registrations.Add(new Registration(source)
+            {
+                StartTimestamp = Stopwatch.GetTimestamp(),
+                LastFrameTimestamp = Stopwatch.GetTimestamp(),
+                NextDue = now, // due immediately so it paints its first frame without delay
+            });
+
+            EnsureLoopRunning();
+        }
+
+        Signal();
+    }
+
+    public void Unregister(IAnimationSource source)
+    {
+        if (source == null) return;
+
+        lock (_gate)
+        {
+            _registrations.RemoveAll(r => ReferenceEquals(r.Source, source));
+        }
+
+        Signal();
+    }
+
+    public void SetGlobalFpsLimit(int fps)
+    {
+        if (fps <= 0) return;
+        Volatile.Write(ref _globalFpsLimit, Math.Min(fps, MaxGlobalFpsLimit));
+        Signal();
+    }
+
+    public void RequestFrame(IAnimationSource source)
+    {
+        if (source == null) return;
+
+        lock (_gate)
+        {
+            if (_disposed) return;
+            var reg = _registrations.FirstOrDefault(r => ReferenceEquals(r.Source, source));
+            if (reg == null) return;
+
+            // Pull its next due time forward to "now" so the loop ticks it on the next pass.
+            reg.NextDue = ElapsedNow();
+            EnsureLoopRunning();
+        }
+
+        Signal();
+    }
+
+    public void Stop()
+    {
+        CancellationTokenSource cts;
+        lock (_gate)
+        {
+            cts = _cts;
+            _cts = null;
+            _loopTask = null;
+        }
+
+        try { cts?.Cancel(); } catch { /* already disposed */ }
+        cts?.Dispose();
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _registrations.Clear();
+        }
+
+        Stop();
+        _wake.Dispose();
+    }
+
+    // ───────────────────────── loop ─────────────────────────
+
+    /// <summary>Caller must hold <see cref="_gate"/>. Starts the loop if it isn't running.</summary>
+    private void EnsureLoopRunning()
+    {
+        if (_disposed || _loopTask != null) return;
+
+        _schedulerStart = Stopwatch.GetTimestamp();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        _loopTask = Task.Run(() => RunLoop(token), token);
+    }
+
+    private async Task RunLoop(CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var sleep = Tick(token);
+
+                // No active sources at all → the loop has nothing to do; let it exit so we
+                // don't hold a parked task forever. A later Register/RequestFrame restarts it.
+                if (sleep == TimeSpan.MaxValue)
+                {
+                    if (TryStopIfNoRegistrations())
+                        return;
+                    sleep = IdlePoll;
+                }
+
+                if (sleep < MinSleep) sleep = MinSleep;
+
+                // WaitAsync returns early (true) when signalled, or on timeout (false); both
+                // just loop again. The permit count is capped at 1, so bursts of signals
+                // collapse into a single early wake — exactly the coalescing we want.
+                await _wake.WaitAsync(sleep, token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on Stop/Dispose
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"AnimationScheduler loop error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Dispatches every due, active, not-in-flight source and returns how long to sleep
+    /// until the next one is due. Returns <see cref="TimeSpan.MaxValue"/> when no source is
+    /// currently active (the caller decides whether to park or stop).
+    /// </summary>
+    private TimeSpan Tick(CancellationToken token)
+    {
+        Registration[] snapshot;
+        int globalLimit;
+        lock (_gate)
+        {
+            if (_registrations.Count == 0) return TimeSpan.MaxValue;
+            snapshot = _registrations.ToArray();
+            globalLimit = _globalFpsLimit;
+        }
+
+        var now = ElapsedNow();
+        var nextWake = TimeSpan.MaxValue;
+        var anyActive = false;
+
+        foreach (var reg in snapshot)
+        {
+            bool active;
+            int targetFps;
+            try
+            {
+                active = reg.Source.IsActive;
+                targetFps = reg.Source.TargetFps;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"AnimationScheduler: source state read threw: {ex.Message}");
+                continue;
+            }
+
+            if (!active)
+            {
+                // Reset due to "now" so a reactivated source fires immediately rather than
+                // replaying a backlog of missed frames.
+                reg.NextDue = now;
+                continue;
+            }
+
+            anyActive = true;
+
+            // Still rendering the previous frame → skip; its completion re-signals the loop.
+            if (Volatile.Read(ref reg.InFlight) != 0)
+                continue;
+
+            var interval = IntervalFor(targetFps, globalLimit);
+
+            if (now >= reg.NextDue)
+            {
+                Dispatch(reg, now, interval, token);
+
+                // Advance one interval to keep cadence; snap forward if we fell behind.
+                reg.NextDue += interval;
+                if (reg.NextDue <= now)
+                    reg.NextDue = now + interval;
+            }
+
+            var until = reg.NextDue - now;
+            if (until < nextWake) nextWake = until;
+        }
+
+        return anyActive ? nextWake : TimeSpan.MaxValue;
+    }
+
+    private void Dispatch(Registration reg, TimeSpan now, TimeSpan interval, CancellationToken token)
+    {
+        Volatile.Write(ref reg.InFlight, 1);
+
+        var startTs = Stopwatch.GetTimestamp();
+        var elapsed = Stopwatch.GetElapsedTime(reg.StartTimestamp, startTs);
+        var delta = Stopwatch.GetElapsedTime(reg.LastFrameTimestamp, startTs);
+        reg.LastFrameTimestamp = startTs;
+
+        var effectiveFps = (int)Math.Round(1.0 / interval.TotalSeconds);
+        var ctx = new AnimationRenderContext(reg.FrameNumber++, elapsed, delta, effectiveFps, token);
+
+        // Fire the render without blocking the loop. On completion we clear the in-flight
+        // flag and wake the loop so the next frame can be scheduled promptly.
+        _ = RenderAndComplete(reg, ctx);
+    }
+
+    private async Task RenderAndComplete(Registration reg, AnimationRenderContext ctx)
+    {
+        try
+        {
+            await reg.Source.RenderFrameAsync(ctx).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected when stopping / unregistering mid-frame
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"AnimationScheduler: source frame threw: {ex.Message}");
+        }
+        finally
+        {
+            Volatile.Write(ref reg.InFlight, 0);
+            Signal();
+        }
+    }
+
+    /// <summary>Stops the loop iff there are no registrations left. Returns true when it stopped.</summary>
+    private bool TryStopIfNoRegistrations()
+    {
+        lock (_gate)
+        {
+            if (_registrations.Count != 0) return false;
+            _loopTask = null;
+            var cts = _cts;
+            _cts = null;
+            // Dispose outside isn't necessary; cancel so any await on this token unwinds.
+            try { cts?.Cancel(); } catch { /* ignore */ }
+            cts?.Dispose();
+            return true;
+        }
+    }
+
+    private TimeSpan IntervalFor(int targetFps, int globalLimit)
+    {
+        var fps = targetFps > 0 ? Math.Min(targetFps, globalLimit) : globalLimit;
+        if (fps <= 0) fps = DefaultGlobalFpsLimit;
+        return TimeSpan.FromSeconds(1.0 / fps);
+    }
+
+    private TimeSpan ElapsedNow() => Stopwatch.GetElapsedTime(_schedulerStart);
+
+    /// <summary>Releases the wake permit if one isn't already pending (count capped at 1).</summary>
+    private void Signal()
+    {
+        try { _wake.Release(); }
+        catch (SemaphoreFullException) { /* a wake is already pending */ }
+        catch (ObjectDisposedException) { /* disposed */ }
+    }
+}

--- a/Services/Animation/IAnimationScheduler.cs
+++ b/Services/Animation/IAnimationScheduler.cs
@@ -1,0 +1,37 @@
+namespace LoupixDeck.Services.Animation;
+
+/// <summary>
+/// The single animation loop for one device. Every animated feature (per-button
+/// effects, full-display screensavers, side-strip transitions, plugin renderers)
+/// registers here instead of spinning up its own timer, so the device has exactly
+/// one render cadence that can be globally rate-limited, paused for inactive pages,
+/// and optimised in one place.
+/// </summary>
+public interface IAnimationScheduler
+{
+    /// <summary>Adds a source to the loop. Idempotent — registering the same instance
+    /// twice is a no-op. Starts the loop if it was idle.</summary>
+    void Register(IAnimationSource source);
+
+    /// <summary>Removes a source. Safe to call at any time, including from inside the
+    /// source's own <see cref="IAnimationSource.RenderFrameAsync"/>. Any frame already
+    /// in flight for the source is allowed to finish.</summary>
+    void Unregister(IAnimationSource source);
+
+    /// <summary>Upper bound on frames per second for every source on this device. A
+    /// source's <see cref="IAnimationSource.TargetFps"/> is clamped to this value. Takes
+    /// effect on the next tick. Values &lt;= 0 are ignored.</summary>
+    void SetGlobalFpsLimit(int fps);
+
+    /// <summary>The current global FPS limit.</summary>
+    int GlobalFpsLimit { get; }
+
+    /// <summary>Wakes the loop so it re-evaluates due times immediately — used when a
+    /// source becomes active again, or has dirty content it wants pushed without waiting
+    /// for its next scheduled frame. No-op if <paramref name="source"/> is not registered.</summary>
+    void RequestFrame(IAnimationSource source);
+
+    /// <summary>Stops the loop and cancels the frame-context token. Registered sources are
+    /// kept, so a later <see cref="Register"/> / <see cref="RequestFrame"/> restarts it.</summary>
+    void Stop();
+}

--- a/Services/Animation/IAnimationSource.cs
+++ b/Services/Animation/IAnimationSource.cs
@@ -1,0 +1,36 @@
+namespace LoupixDeck.Services.Animation;
+
+/// <summary>
+/// One animated thing the central scheduler drives — a per-button effect, a
+/// full-display screensaver, a side-strip transition, a plugin renderer, etc.
+///
+/// A source never owns a timer or render loop of its own: it registers with the
+/// <see cref="IAnimationScheduler"/>, declares the rate it would like via
+/// <see cref="TargetFps"/>, and gates whether it currently wants frames via
+/// <see cref="IsActive"/>. The scheduler calls <see cref="RenderFrameAsync"/> on a
+/// background thread at the (globally clamped) cadence while the source is active.
+///
+/// Sources that only change occasionally should keep returning quickly when nothing
+/// changed (dirty-state lives in the source) and/or flip <see cref="IsActive"/> to
+/// <c>false</c> when idle so the scheduler stops ticking them entirely.
+/// </summary>
+public interface IAnimationSource
+{
+    /// <summary>Desired frame rate. A value &lt;= 0 means "use the scheduler's global
+    /// limit". The scheduler always clamps the effective rate to the global limit.</summary>
+    int TargetFps { get; }
+
+    /// <summary>Whether the source currently wants to be driven. Polled by the scheduler
+    /// every tick, so flipping it to <c>false</c> (e.g. when the owning page is no longer
+    /// the active page) pauses rendering without unregistering. Flip it back to <c>true</c>
+    /// and call <see cref="IAnimationScheduler.RequestFrame"/> to resume immediately.</summary>
+    bool IsActive { get; }
+
+    /// <summary>Renders one frame. Invoked on a background thread; Skia work must still go
+    /// through <see cref="LoupixDeck.Utils.SkiaRenderGate.Sync"/> and UI-bound mutations must
+    /// be posted to the dispatcher, exactly as the rest of the device pipeline does. The
+    /// scheduler never starts a new frame for this source while the previous one is still
+    /// running, so a slow render simply lowers this source's effective rate instead of
+    /// piling up.</summary>
+    Task RenderFrameAsync(AnimationRenderContext context);
+}


### PR DESCRIPTION
Introduce a per-device central animation loop so future animated features (per-button effects, full-display screensavers, side-strip transitions, plugin renderers) share one timing source instead of each owning a timer.

- IAnimationSource: TargetFps / IsActive / RenderFrameAsync(context)
- AnimationRenderContext: shared high-res timing snapshot per frame
- IAnimationScheduler + AnimationScheduler: single background loop with per-source FPS clamped to a global limit, dirty-state via RequestFrame, inactive sources skipped (paused), in-flight guard, no busy-spin
- Registered per-device alongside IDynamicTextManager; controller stops it on Shutdown; App disposes it on hot-unplug

No animation consumers yet (later sub-issues #120-#125, #139); this is the scheduling foundation only. Builds clean.