### PR TITLE
Converted runtime constructed regex to compiletime specialized regex

### DIFF
--- a/LoupixDeck/Services/Macros/MacroContext.cs
+++ b/LoupixDeck/Services/Macros/MacroContext.cs
@@ -50,7 +50,7 @@ public sealed partial class MacroContext
 
     // Matches {name} placeholders; the name is anything but braces so nesting is rejected.
 
-    [GeneratedRegex(@"\{([^{}]+)\}", RegexOptions.Compiled)]
+    [GeneratedRegex(@"\{([^{}]+)\}", RegexOptions.CultureInvariant)]
     private static partial Regex PlaceholderPattern { get; }
 
     /// <summary>

--- a/LoupixDeck/Utils/CommandStringParser.cs
+++ b/LoupixDeck/Utils/CommandStringParser.cs
@@ -8,11 +8,12 @@ namespace LoupixDeck.Utils;
 /// touch-button command editor split and dissect commands identically — they must
 /// not drift apart, or a string the editor builds could be executed differently.
 /// </summary>
-public static class CommandStringParser
+public static partial class CommandStringParser
 {
     // Splits on "&&" with any amount of surrounding whitespace, so both
     // "a && b" and "a&&b" are treated the same.
-    private static readonly Regex ChainSplitter = new(@"\s*&&\s*", RegexOptions.Compiled);
+    [GeneratedRegex(@"\s*&&\s*")]
+    private static partial Regex ChainSplitter { get; }
 
     /// <summary>Splits a chained command into its individual segments (already trimmed,
     /// empty segments removed).</summary>

--- a/LoupixDeck/Utils/CommandStringParser.cs
+++ b/LoupixDeck/Utils/CommandStringParser.cs
@@ -12,7 +12,7 @@ public static partial class CommandStringParser
 {
     // Splits on "&&" with any amount of surrounding whitespace, so both
     // "a && b" and "a&&b" are treated the same.
-    [GeneratedRegex(@"\s*&&\s*")]
+    [GeneratedRegex(@"\s*&&\s*", RegexOptions.CultureInvariant)]
     private static partial Regex ChainSplitter { get; }
 
     /// <summary>Splits a chained command into its individual segments (already trimmed,

--- a/LoupixDeck/Utils/SerialDeviceInfo.cs
+++ b/LoupixDeck/Utils/SerialDeviceInfo.cs
@@ -24,13 +24,13 @@ public static partial class SerialDeviceHelper
     );
 
 #if WINDOWS
-    [GeneratedRegex(@"PID_([0-9A-F]{4})", RegexOptions.IgnoreCase, "en-US")]
+    [GeneratedRegex(@"PID_([0-9A-F]{4})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex regexPid { get; }
 
-    [GeneratedRegex(@"VID_([0-9A-F]{4})", RegexOptions.IgnoreCase, "en-US")]
+    [GeneratedRegex(@"VID_([0-9A-F]{4})", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex regexVid { get; }
 
-    [GeneratedRegex(@"\(COM(\d+)\)", RegexOptions.IgnoreCase, "en-US")]
+    [GeneratedRegex(@"\(COM(\d+)\)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex regexCom { get; }
 
     // SuppressMessage rather than [SupportedOSPlatform] — the latter cascades to

--- a/LoupixDeck/Utils/SerialDeviceInfo.cs
+++ b/LoupixDeck/Utils/SerialDeviceInfo.cs
@@ -7,7 +7,7 @@ using System.Management;
 using System.Text.RegularExpressions;
 #endif
 
-public static class SerialDeviceHelper
+public static partial class SerialDeviceHelper
 {
     // NormalizedSerial is the platform-uniform identity value (Windows hex→ASCII
     // decoded, '&'-synthesized location ids → null); Serial keeps the raw value
@@ -24,6 +24,15 @@ public static class SerialDeviceHelper
     );
 
 #if WINDOWS
+    [GeneratedRegex(@"PID_([0-9A-F]{4})", RegexOptions.IgnoreCase, "en-US")]
+    private static partial Regex regexPid { get; }
+
+    [GeneratedRegex(@"VID_([0-9A-F]{4})", RegexOptions.IgnoreCase, "en-US")]
+    private static partial Regex regexVid { get; }
+
+    [GeneratedRegex(@"\(COM(\d+)\)", RegexOptions.IgnoreCase, "en-US")]
+    private static partial Regex regexCom { get; }
+
     // SuppressMessage rather than [SupportedOSPlatform] — the latter cascades to
     // every caller and forces platform attributes on otherwise cross-platform
     // code (the Linux #else branch implements the same API). The WMI call is
@@ -33,9 +42,6 @@ public static class SerialDeviceHelper
     public static List<SerialDeviceInfo> ListSerialUsbDevices()
     {
         var result = new List<SerialDeviceInfo>();
-        var regexVid = new Regex(@"VID_([0-9A-F]{4})", RegexOptions.IgnoreCase);
-        var regexPid = new Regex(@"PID_([0-9A-F]{4})", RegexOptions.IgnoreCase);
-        var regexCom = new Regex(@"\(COM(\d+)\)", RegexOptions.IgnoreCase);
 
         using var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_PnPEntity WHERE Name LIKE '%(COM%'");
 


### PR DESCRIPTION
There is discussion to be had on the resulting code when `cultureName` is unassigned vs "en-US"