### PR TITLE
Filter plugin commands/menus to the enabling device (#163)

### DIFF
--- a/LoupixDeck/Services/Commands/PluginCommandProvider.cs
+++ b/LoupixDeck/Services/Commands/PluginCommandProvider.cs
@@ -1,4 +1,5 @@
 using LoupixDeck.Commands.Base;
+using LoupixDeck.Models;
 using LoupixDeck.PluginSdk;
 using LoupixDeck.Services.Plugins;
 
@@ -12,10 +13,12 @@ namespace LoupixDeck.Services.Commands;
 public class PluginCommandProvider : ICommandProvider
 {
     private readonly IPluginManager _pluginManager;
+    private readonly LoupedeckConfig _config;
 
-    public PluginCommandProvider(IPluginManager pluginManager)
+    public PluginCommandProvider(IPluginManager pluginManager, LoupedeckConfig config)
     {
         _pluginManager = pluginManager;
+        _config = config;
     }
 
     public IEnumerable<RegisteredCommand> GetCommands()
@@ -25,6 +28,13 @@ public class PluginCommandProvider : ICommandProvider
         foreach (var plugin in _pluginManager.Plugins)
         {
             if (plugin.Status != PluginLoadStatus.Loaded)
+                continue;
+
+            // Plugins load once and are shared across devices (union enable-gate), but this
+            // provider feeds a per-device registry. Filter to the plugins THIS device has
+            // enabled, so a command contributed by a plugin another device enabled does not
+            // become assignable/executable here (issue #163).
+            if (!PluginEnabledForDevice(plugin.Manifest?.Id))
                 continue;
 
             foreach (var command in plugin.Commands)
@@ -42,6 +52,17 @@ public class PluginCommandProvider : ICommandProvider
         }
 
         return result;
+    }
+
+    /// <summary>True when this device's config enables the plugin with the given id.</summary>
+    private bool PluginEnabledForDevice(string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(pluginId))
+            return false;
+
+        var enabled = _config?.EnabledPlugins;
+        return enabled != null
+               && enabled.Any(id => string.Equals(id, pluginId, StringComparison.OrdinalIgnoreCase));
     }
 
     private static RegisteredCommand Adapt(IPluginCommand command, IPluginHost host)

--- a/LoupixDeck/Services/Commands/PluginMenuContributor.cs
+++ b/LoupixDeck/Services/Commands/PluginMenuContributor.cs
@@ -16,11 +16,16 @@ public class PluginMenuContributor : IPluginMenuSource
 {
     private readonly IPluginManager _pluginManager;
     private readonly ICommandBuilder _commandBuilder;
+    private readonly Models.LoupedeckConfig _config;
 
-    public PluginMenuContributor(IPluginManager pluginManager, ICommandBuilder commandBuilder)
+    public PluginMenuContributor(
+        IPluginManager pluginManager,
+        ICommandBuilder commandBuilder,
+        Models.LoupedeckConfig config)
     {
         _pluginManager = pluginManager;
         _commandBuilder = commandBuilder;
+        _config = config;
     }
 
     public IReadOnlyList<DeferredMenuSource> GetDeferredSources(ButtonTargets target)
@@ -30,6 +35,12 @@ public class PluginMenuContributor : IPluginMenuSource
         foreach (var plugin in _pluginManager.Plugins)
         {
             if (plugin.Status != PluginLoadStatus.Loaded)
+                continue;
+
+            // Plugins are shared across devices; only surface a plugin's menu on the
+            // device that enabled it, so its commands aren't shown (and can't be
+            // assigned) on a device where the plugin is inactive (issue #163).
+            if (!PluginEnabledForDevice(plugin.Manifest?.Id))
                 continue;
 
             if (plugin.Instance is not SdkMenuContributor contributor)
@@ -62,6 +73,17 @@ public class PluginMenuContributor : IPluginMenuSource
         }
 
         return sources;
+    }
+
+    /// <summary>True when this device's config enables the plugin with the given id.</summary>
+    private bool PluginEnabledForDevice(string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(pluginId))
+            return false;
+
+        var enabled = _config?.EnabledPlugins;
+        return enabled != null
+               && enabled.Any(id => string.Equals(id, pluginId, StringComparison.OrdinalIgnoreCase));
     }
 
     private static IReadOnlyList<string> SafeGetGroupNames(LoupixPlugin plugin)


### PR DESCRIPTION
Plugins load once and are shared across all devices, gated by a union of the per-device enable sets. But the per-device command registry and menu were fed from the full loaded-plugin list without re-checking the current device's LoupedeckConfig.EnabledPlugins. A plugin enabled on one device therefore had its commands shown and assignable on every other device too.

PluginCommandProvider and PluginMenuContributor now filter to plugins this device enables, so an inactive plugin contributes neither registry entries nor menu nodes here. Already-saved command strings for a plugin inactive on a device still load (rendered as free-text "unknown" chips) and round-trip unchanged, so re-enabling the plugin restores the real chip.