### PR TITLE
[codex] Document monitoring plugin tiles

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -408,12 +408,13 @@ The current binary installation includes these plugin manifests:
 | CoolerControl | All |
 | Argus Monitor | Windows |
 | HWiNFO | Windows |
+| LibreHardwareMonitor | Windows |
 
 Plugins can add commands, dynamic text, settings pages, folders, side-strip providers, or special integration behavior. The exact command names depend on the installed plugin version and what external app or service is configured.
 
 ### Monitoring Plugins
 
-Argus Monitor, HWiNFO, and LibreHardwareMonitor can show sensor readings on touch buttons when the matching plugin is installed and enabled.
+Argus Monitor, HWiNFO, and LibreHardwareMonitor can show sensor readings on touch buttons when the matching plugin is installed and enabled. LibreHardwareMonitor is bundled with LoupixDeck starting in v1.13.1.
 
 In current releases, sensor commands render as monitoring tiles instead of plain text. A tile can show:
 
@@ -426,6 +427,8 @@ You can put several sensor readings on one touch button by chaining sensor comma
 Some monitoring plugins also offer a transparent background option. When enabled, the tile panel is removed so the page wallpaper shows through; text is outlined to stay readable.
 
 Monitoring plugin settings are device-specific. If you enable a plugin on one connected device, its commands and menu entries do not automatically appear on another device. Saved buttons still load, and re-enabling the plugin for that device restores the real command chips.
+
+LibreHardwareMonitor setup has one extra requirement: LibreHardwareMonitor itself must be running in the background. In LibreHardwareMonitor, enable its HTTP web server in the settings. Current LibreHardwareMonitor versions use this HTTP server for external access; the LoupixDeck plugin does not need one exact LibreHardwareMonitor build, but it expects a version newer than v0.8.5. If you enable authentication for the HTTP server, enter the same username and password in the plugin settings. If authentication is off, leave those fields empty.
 
 ## Device Power and Window Commands
 
@@ -619,6 +622,7 @@ Recording needs read access to `/dev/input/event*`. The installer attempts to ha
 - If you use more than one device, enable the plugin on the device where you want to use it.
 - Restart LoupixDeck if the plugin page says some changes need a restart.
 - Confirm that external services such as OBS, Spotify, or monitoring tools are running and configured.
+- For LibreHardwareMonitor, confirm that LibreHardwareMonitor is running in the background and that its HTTP web server is enabled. If the web server uses authentication, check the username and password in the plugin settings.
 
 ### Monitoring tiles look wrong or still use old settings
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -411,6 +411,22 @@ The current binary installation includes these plugin manifests:
 
 Plugins can add commands, dynamic text, settings pages, folders, side-strip providers, or special integration behavior. The exact command names depend on the installed plugin version and what external app or service is configured.
 
+### Monitoring Plugins
+
+Argus Monitor, HWiNFO, and LibreHardwareMonitor can show sensor readings on touch buttons when the matching plugin is installed and enabled.
+
+In current releases, sensor commands render as monitoring tiles instead of plain text. A tile can show:
+
+- Sensor name or header.
+- Current value.
+- Gauge bar.
+
+You can put several sensor readings on one touch button by chaining sensor commands with `&&`. LoupixDeck draws one row per sensor, up to four rows. If the button has only one sensor command, it uses a larger single-value tile layout.
+
+Some monitoring plugins also offer a transparent background option. When enabled, the tile panel is removed so the page wallpaper shows through; text is outlined to stay readable.
+
+Monitoring plugin settings are device-specific. If you enable a plugin on one connected device, its commands and menu entries do not automatically appear on another device. Saved buttons still load, and re-enabling the plugin for that device restores the real command chips.
+
 ## Device Power and Window Commands
 
 Device control commands can be assigned to buttons or run from automation:
@@ -600,8 +616,13 @@ Recording needs read access to `/dev/input/event*`. The installer attempts to ha
 
 - Open `Settings > Plugins`.
 - Check whether the plugin is installed and enabled.
+- If you use more than one device, enable the plugin on the device where you want to use it.
 - Restart LoupixDeck if the plugin page says some changes need a restart.
 - Confirm that external services such as OBS, Spotify, or monitoring tools are running and configured.
+
+### Monitoring tiles look wrong or still use old settings
+
+Sensor plugins changed from plain text output to tile rendering. If an old Argus, HWiNFO, or LibreHardwareMonitor button looks wrong after updating, remove the old sensor command or plugin-specific layer/settings from the button and add the sensor command again.
 
 ### Collecting crash logs
 


### PR DESCRIPTION
Updates the user manual for v1.13.0 monitoring plugin changes.

Changes:
- Adds a Monitoring Plugins section for Argus Monitor, HWiNFO, and LibreHardwareMonitor sensor buttons.
- Documents tile rendering with header/value/gauge bar.
- Explains chaining sensor commands with `&&` for up to four rows on one button.
- Notes the transparent background option and device-specific plugin enablement.
- Adds troubleshooting guidance for old sensor settings after updating.

Validation:
- Verified against the v1.13.0 release notes.
- Ran `git diff --check`.