### PR TITLE
[codex] Update manual for v1.18.3

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -257,14 +257,14 @@ In the touch button editor you can:
 - Delete a state.
 - Give each state its own layers and command sequence.
 
-The `Transition after press` setting controls what happens after the button runs:
+The `Transition after press` setting controls what happens when you press the button:
 
 - Stay in the current state.
 - Move to the next/previous state.
 - Jump to a specific state.
 - Return to the default state.
 
-Exact transition names may vary, but the idea is simple: a button can press, do work, and then choose its next visual/action state.
+The transition is applied immediately at press time, using the state that was active for that press. The command sequence then continues running separately. This means a long macro, a macro with a delay, or an endless repeat loop does not keep the old visual state on screen until the command finishes. It also prevents a late transition from undoing a newer press. For example, a start/stop macro pair now changes state and works in two presses, even when one macro keeps running.
 
 ## Commands and Command Sequences
 


### PR DESCRIPTION
Updates docs/USER_MANUAL.md for v1.18.3.

The Profile Rules section already contains the release's three explicit no-match behaviors from upstream. This change corrects the Button States section so it explains that `Transition after press` is applied immediately at press time, while the assigned command or macro continues running. It also documents why long macros, delays, repeat loops, and start/stop macro pairs behave correctly with the new timing.

Validation: `git diff --check` passed; the branch is based on v1.18.3 `origin/master`; the fork branch was verified with `git ls-remote`.