### PR TITLE
[codex] Update manual for v1.19.1

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -103,6 +103,8 @@ loupixdeck
 
 On start, LoupixDeck auto-detects supported USB devices. If a device is connected, the main window opens with a visual layout matching the device.
 
+If no device is connected, the device area shows `No device connected` instead of empty profile and workspace selectors. Plug a supported deck in over USB and LoupixDeck picks it up automatically; after a re-plug, the layout and the device-bound parts of the window are restored. Until a device is available, actions that need a device are disabled, but `Quit` remains available from the hamburger menu.
+
 If the app cannot talk to the device:
 
 - Check that the device is plugged in directly or through a reliable hub.


### PR DESCRIPTION
Updates docs/USER_MANUAL.md for v1.19.1.

The v1.19.0 macro documentation is already included upstream and covers the full keyboard key set, key-name reference, held-key workflow, release timeout, and automatic release safety. This change adds the v1.19.1 device-connection behavior: the explicit no-device panel, automatic layout restoration after re-plugging, disabled device-dependent actions, and the Quit command remaining available without a device.

Validation: `git diff --check` passed; the branch is based on v1.19.1 `origin/master`; the fork branch was verified with `git ls-remote`.