### PR TITLE
[codex] Document v1.22.0 plugin rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built with **Avalonia** and **.NET 10**.
 * **OBS Studio**, **Elgato Key Lights**, **Cooler Control**, **Argus Monitor** and **Windows Audio** integrations
 * **Portable profiles** — export a profile, workspace or page as a `.loupixprofile` file and import it anywhere
 * **Local CLI / IPC automation** for scripts and external tools
-* **Plugin SDK** for custom commands, dynamic text providers and settings UI
+* **Plugin SDK** for custom commands, dynamic text, settings UI, plugin screensavers and animated side strips
 
 ---
 
@@ -173,9 +173,14 @@ Built-in commands and dynamic values are available for:
 
 Play a full-display animated screensaver after a configurable idle time.
 
-* GIF or MP4 source
+* Video/GIF or plugin-provided source
 * Adjustable idle timeout
 * Wakes on the next touch or control interaction
+* `ffmpeg` is needed only for video sources; plugin renderers supply their own frames
+
+### Runtime Efficiency
+
+The display pipeline reuses pooled frame buffers, masks WebSocket payloads in place and parses incoming serial data on a fixed buffer. Command parsing, frozen lookup tables and generated native interop further reduce temporary allocations while displays and animations are updating. These optimisations are automatic and need no user configuration.
 
 ### App-Focus Page Switching
 
@@ -266,7 +271,11 @@ Plugins can provide:
 * custom commands
 * dynamic text providers
 * settings UI
+* full-display screensavers
+* static or animated side-strip renderers
 * integration-specific functionality
+
+Plugins installed from a zip live in the user plugin folder. When a user plugin and a bundled plugin have the same id, LoupixDeck loads the higher manifest version; a version tie favours the user copy. This lets a newer zip update a built-in plugin without modifying the application folder. If a later LoupixDeck release bundles a newer version, that bundled copy takes over automatically. Removing a user override restores the bundled copy instead of uninstalling the plugin.
 
 The Plugin SDK is maintained in a separate repository:
 

--- a/docs/PluginSdk/API-Host-Services.md
+++ b/docs/PluginSdk/API-Host-Services.md
@@ -16,6 +16,10 @@ public interface IPluginHost
     void RequestButtonRefresh(string commandName);
     void ExecuteCommand(string command);
     void OpenFolder(IFolderProvider provider);
+
+    IFullDisplayRenderSession? RequestFullDisplayRenderer(IFullDisplayRenderer renderer);
+    // display takeovers: see Exclusive Mode for RequestExclusiveMode /
+    // ReleaseExclusiveMode / IsInExclusiveMode
 }
 ```
 
@@ -27,6 +31,7 @@ public interface IPluginHost
 | `RequestButtonRefresh(commandName)` | Asks the host to re-render every touch button bound to `commandName`. Use after data backing an `IDisplayCommand` changes via push so the user sees the new value immediately instead of at the next poll tick. |
 | `ExecuteCommand(command)` | Runs a command string through the host's command pipeline (`Plugin.Command(arg1,arg2)` syntax). Enables chaining across plugin boundaries — e.g. an action that triggers another plugin's command. |
 | `OpenFolder(provider)` | Pushes a [folder navigation view](Advanced-Folders) onto the touch screen. The host calls `provider.OnEnter()` and starts rendering from `provider.BuildEntries()`. |
+| `RequestFullDisplayRenderer(renderer)` | Takes the **whole display** over and streams raw BGRA frames from your [`IFullDisplayRenderer`](Advanced-Full-Display-Renderer) on the host's animation scheduler. Returns the ownership session, or `null` when the display is already taken. Release it in `Shutdown()`. |
 
 Keep the `IPluginHost` you received in `Initialize` for the plugin's lifetime —
 do not try to access host services from a static field or before `Initialize`

--- a/docs/PluginSdk/API-LoupixPlugin.md
+++ b/docs/PluginSdk/API-LoupixPlugin.md
@@ -11,6 +11,9 @@ public abstract class LoupixPlugin
     public virtual  void Initialize(IPluginHost host) { }
     public virtual  void Shutdown() { }
     public abstract IEnumerable<IPluginCommand> GetCommands();
+    public virtual  IReadOnlyList<CommandGroupDescriptor> GetCommandGroups() => [];
+    public virtual  IEnumerable<ISideStripProvider> GetSideStripProviders() => [];
+    public virtual  IEnumerable<IScreensaverProvider> GetScreensaverProviders() => [];
 }
 ```
 
@@ -37,6 +40,23 @@ Returns all commands the plugin contributes. Called once per load. Yielding
 zero commands is legal (e.g. a plugin that only contributes settings or a
 folder view).
 
+### `GetCommandGroups()`
+
+Returns optional descriptors for command-picker groups. Groups without a
+descriptor still load with the host's generic plugin presentation.
+
+### `GetSideStripProviders()`
+
+Returns side-strip renderer factories that users can bind to a rotary page in
+`PluginOverride` mode. A provider creates an independent session for each side
+attachment. See [Plugin Screensavers and Animated Side Strips](Advanced-Screensavers-and-Side-Strips#side-strip-providers).
+
+### `GetScreensaverProviders()`
+
+Returns discoverable screensaver factories shown when the user selects
+`Plugin` in `Settings > Screensaver`. The host creates a fresh renderer for
+each idle run. See [Plugin Screensavers and Animated Side Strips](Advanced-Screensavers-and-Side-Strips#plugin-screensavers).
+
 ### `Shutdown()`
 
 Called on plugin unload or application exit. Release resources, cancel timers,
@@ -45,7 +65,7 @@ close sockets. Default implementation does nothing.
 ## Lifecycle ordering
 
 ```
-ctor → Initialize(host) → GetCommands() → … → Shutdown()
+ctor → Initialize(host) → collect commands/groups/providers → … → Shutdown()
 ```
 
 The host never calls `Initialize` twice. `Shutdown` runs at most once and may

--- a/docs/PluginSdk/API-Reference.md
+++ b/docs/PluginSdk/API-Reference.md
@@ -38,7 +38,17 @@ interfaces, and a few value types. Everything lives in the
 | `FolderLayout` | [Folder Navigation](Advanced-Folders#folderlayout) | Grid geometry constants. |
 | `RotaryOverride` | [Folder Navigation](Advanced-Folders#rotaryoverride) | Per-encoder behavior while a folder is open. |
 | `IExclusiveModeProvider` | [Exclusive Mode](Advanced-Exclusive-Mode#iexclusivemodeprovider) | Full-device takeover (HUD, screensaver, video). |
-| `ExclusiveRenderMode` | [Exclusive Mode](Advanced-Exclusive-Mode#exclusiverendermode) | How the host pushes a provider's frames (full screen / grid / dirty tiles / single tile). |
+| `ExclusiveRenderMode` | [Exclusive Mode](Advanced-Exclusive-Mode#exclusiverendermode) | How the host pushes a provider's frames, including `None` for provider-owned output. |
+| `IFullDisplayRenderer` | [Full-Display Renderer](Advanced-Full-Display-Renderer#ifulldisplayrenderer) | Streams raw BGRA frames to the whole display (video, visualizers). |
+| `IFullDisplayRenderSession` | [Full-Display Renderer](Advanced-Full-Display-Renderer#requesting-the-display) | Ownership handle for an active full-display takeover. |
+| `FullDisplaySurface` | [Full-Display Renderer](Advanced-Full-Display-Renderer#the-frame-buffer) | Geometry and pixel layout of the frame buffer. |
+| `FullDisplayFrameContext` | [Full-Display Renderer](Advanced-Full-Display-Renderer#timing) | Per-frame timing snapshot. |
+| `FullDisplayFrameResult` | [Full-Display Renderer](Advanced-Full-Display-Renderer#renderframe-must-be-fast) | What the renderer did this tick (skip / frame / final). |
+| `IScreensaverProvider` | [Plugin Rendering](Advanced-Screensavers-and-Side-Strips#plugin-screensavers) | Discoverable full-display renderer factory for the host's idle screensaver. |
+| `ISideStripProvider` | [Plugin Rendering](Advanced-Screensavers-and-Side-Strips#side-strip-providers) | Renderer factory that can own one side strip for a rotary page. |
+| `ISideStripSession` | [Plugin Rendering](Advanced-Screensavers-and-Side-Strips#side-strip-providers) | One live, disposable strip attachment. |
+| `IAnimatedSideStripSession` | [Plugin Rendering](Advanced-Screensavers-and-Side-Strips#animated-side-strip-sessions) | Optional scheduler-driven animation capability for a strip session. |
+| `AnimationFrameInfo` | [Plugin Rendering](Advanced-Screensavers-and-Side-Strips#frame-results-and-timing) | Dirty key and skip/frame/final result for an animated strip frame. |
 | `IPluginSettingsPage` | [Settings Page](Advanced-Settings-Page#ipluginsettingspage) | Exposes user-editable settings. |
 | `PluginSettingDescriptor` | [Settings Page](Advanced-Settings-Page#pluginsettingdescriptor) | One editable setting. |
 | `PluginSettingKind` | [Settings Page](Advanced-Settings-Page#pluginsettingkind) | Editor kind enum. |
@@ -50,10 +60,15 @@ interfaces, and a few value types. Everything lives in the
 ```csharp
 public static class SdkInfo
 {
-    public static readonly Version Version = new(1, 2, 0);
+    public static readonly Version Version = new(1, 20, 0);
 }
 ```
 
 Always set `PluginMetadata.SdkVersion = SdkInfo.Version`. The host loads a
 plugin only when `SdkVersion.Major` matches its own — within a major version,
 the contracts are guaranteed source- and binary-compatible.
+
+SDK 1.20.0 adds optional screensaver and animated-side-strip contracts plus
+`ExclusiveRenderMode.None`. These changes are additive: existing 1.x plugins
+continue to load without a rebuild. The package targets both `net9.0` and
+`net10.0` so plugins on either target can reference the same contract version.

--- a/docs/PluginSdk/Advanced-Exclusive-Mode.md
+++ b/docs/PluginSdk/Advanced-Exclusive-Mode.md
@@ -76,7 +76,8 @@ public enum ExclusiveRenderMode
     FullScreen,  // 0 — composite all slots, one full-screen blit + DRAW
     Grid,        // 1 — every slot as its own 90x90 tile, no DRAW
     DirtyTiles,  // 2 — only the tiles whose content changed, no DRAW
-    SingleTile   // 3 — one slot (SingleTileSlot), no DRAW
+    SingleTile,  // 3 — one slot (SingleTileSlot), no DRAW
+    None         // 4 — host pushes nothing; provider writes its own frames
 }
 ```
 
@@ -86,6 +87,7 @@ public enum ExclusiveRenderMode
 | `Grid` | All 15 slots as individual 90×90 framebuffers, no `DRAW`. | Full-grid content that changes a lot every frame. |
 | `DirtyTiles` | Only the slots whose **visible content changed** since the last frame, no `DRAW`. | Per-tile **live data** where just a few slots move each frame — telemetry HUDs, dashboards. |
 | `SingleTile` | One 90×90 slot (`SingleTileSlot`), no `DRAW`. | Streaming a GIF/video onto a single button. |
+| `None` | No host-rendered framebuffer. Exclusive mode still suppresses normal pages and routes input to the provider. | Providers that write their own frames outside the host's slot model. |
 
 Rough throughput on a Loupedeck Live S (≈115 kbit serial): a single 90×90 tile
 reaches several hundred fps, while a full-screen blit tops out around ~44 fps.
@@ -158,3 +160,16 @@ public sealed class SpeedHud : IExclusiveModeProvider
   strategy at runtime if needed (e.g. `Grid` on entry, `DirtyTiles` once steady).
 - **Pick the cheapest mode that looks right.** `DirtyTiles` for live dashboards,
   `FullScreen` or `Grid` for a screensaver, `SingleTile` for one-button media.
+- **Use `None` only when you own output transport.** The host will not paint or
+  refresh the display for you, so your provider must push every frame it needs.
+  Input routing and exclusive ownership still behave normally.
+- **Start it from a command, not automatically.** Enter exclusive mode in response
+  to an explicit command the user runs (an `IPluginCommand`), not implicitly when
+  the plugin loads/initializes or a game is detected. This keeps two exclusive-mode
+  plugins from fighting over the device and lets one plugin expose several different
+  takeovers (one start command each).
+- **A profile/workspace switch ends the takeover.** The host calls `OnExit` and
+  restores the normal page when the active profile or workspace changes (the
+  takeover belonged to the workspace being left). It does **not** auto-restart —
+  the user re-enters by running your start command again. Keep `OnExit` cheap and
+  idempotent; don't try to re-enter from inside it.

--- a/docs/PluginSdk/Advanced-Full-Display-Renderer.md
+++ b/docs/PluginSdk/Advanced-Full-Display-Renderer.md
@@ -1,0 +1,201 @@
+# Full-Display Renderer
+
+A *full-display renderer* streams raw framebuffers to the **entire device
+display**, driven by the host's central animation scheduler. Use it for
+continuously animated full-screen content: a video, a visualizer, a telemetry
+dashboard that redraws every frame.
+
+It is the high-throughput sibling of [exclusive mode](Advanced-Exclusive-Mode):
+
+| | Exclusive mode | Full-display renderer |
+|---|---|---|
+| You deliver | Per-slot [`FolderEntry`](Advanced-Folders#folderentry) tiles (text/PNG) | One contiguous BGRA framebuffer per frame |
+| Host does | Decode + composite + push | Push |
+| Input | Every hardware input is routed to you | Buttons are inert; **any press ends the takeover** |
+| Best for | HUDs, dashboards, menus, anything interactive | Video, visualizers, continuous animation |
+
+Both take the whole display, so they are **mutually exclusive**: whoever owns it
+first wins, and neither steals from the other.
+
+## Requesting the display
+
+```csharp
+IFullDisplayRenderSession? session = host.RequestFullDisplayRenderer(myRenderer);
+if (session == null)
+{
+    // Display already owned (another full-display renderer or exclusive mode),
+    // no active device, or your OnStart threw. Handle it — don't assume success.
+    return;
+}
+
+_session = session;   // keep it; releasing it is how you give the display back
+```
+
+The returned `IFullDisplayRenderSession` **is** the ownership handle:
+
+```csharp
+public interface IFullDisplayRenderSession : IDisposable
+{
+    bool IsActive { get; }   // false once released or revoked by the host
+    void Release();          // idempotent; same as Dispose()
+}
+```
+
+Release it when you're done — and **always release it in `Shutdown()`**, so an
+unload tears your renderer down deterministically.
+
+## IFullDisplayRenderer
+
+```csharp
+public interface IFullDisplayRenderer
+{
+    int  TargetFps { get; }
+    bool IsActive  { get; }
+
+    void OnStart(FullDisplaySurface surface);
+    void OnStop();
+
+    FullDisplayFrameResult RenderFrame(byte[] buffer, in FullDisplayFrameContext frame);
+}
+```
+
+| Member | Notes |
+|---|---|
+| `TargetFps` | Desired frame rate. The host raises its global animation cap to this value for the duration of the session; `<= 0` means "use the host default". Read `frame.EffectiveFps` for the rate you actually get. |
+| `IsActive` | Polled every tick. Returning `false` pauses frame pulls cheaply **without** releasing the session — use it when your producer has nothing to show. |
+| `OnStart(surface)` | Called once, off the UI thread, when the session is granted, with the exact target geometry. Start decoding/producing here. Throwing here fails the request (`RequestFullDisplayRenderer` returns `null`). |
+| `OnStop()` | Called once when the session is released — by you, by a profile switch, by a button press, on plugin unload, or at host teardown. Stop decoding and free resources. |
+| `RenderFrame(buffer, frame)` | Fill `buffer` with one frame. Called off the UI thread at up to `TargetFps`. |
+
+### The frame buffer
+
+```csharp
+public readonly struct FullDisplaySurface
+{
+    public int Width  { get; init; }   // device pixels
+    public int Height { get; init; }
+    public int Stride { get; init; }   // bytes per row — Width * 4 for BGRA
+    public FullDisplayPixelFormat PixelFormat { get; init; }   // Bgra8888 today
+}
+```
+
+The `buffer` handed to `RenderFrame` is **host-owned and pooled**:
+
+- It holds *at least* `Stride * Height` bytes. Write exactly that many.
+- **Never read `buffer.Length`** — a pooled array may be larger than the frame.
+- Don't keep a reference to it after `RenderFrame` returns; it goes back to the
+  pool.
+
+### RenderFrame must be fast
+
+`RenderFrame` runs on the scheduler thread. Decode/produce **asynchronously** on
+your own thread and just copy the freshest frame here — a blocking call stalls
+every other animation on the device.
+
+Report what you did with `FullDisplayFrameResult`:
+
+```csharp
+FullDisplayFrameResult.Skip()               // nothing new this tick — host leaves the display alone
+FullDisplayFrameResult.Frame(frameNumber)   // wrote a frame; stream continues
+FullDisplayFrameResult.Final(frameNumber)   // wrote the last frame; host stops ticking and holds it
+```
+
+`frameNumber` is a **monotonic dirty key**: the host only pushes to the device
+when it differs from the last pushed value, so repeating a number costs no
+serial I/O. After `Final` the session stays open (the last frame stays on
+screen) until you release it.
+
+### Timing
+
+```csharp
+public readonly struct FullDisplayFrameContext
+{
+    public long              FrameNumber       { get; init; }   // since ticking started
+    public TimeSpan          Elapsed           { get; init; }
+    public TimeSpan          Delta             { get; init; }   // since the previous frame
+    public int               EffectiveFps      { get; init; }   // after host clamping
+    public FullDisplaySurface Surface          { get; init; }
+    public CancellationToken CancellationToken { get; init; }   // cancelled on host teardown
+}
+```
+
+Drive your output from `Elapsed` / `Delta` rather than counting ticks — the
+effective rate can be lower than `TargetFps`.
+
+## Example: streaming decoded frames
+
+```csharp
+public sealed class VideoRenderer : IFullDisplayRenderer
+{
+    private readonly object _gate = new();
+    private byte[]? _latest;          // produced by the decoder thread
+    private long _produced;
+    private long _handedOut = -1;
+
+    public int TargetFps => 30;
+    public bool IsActive => true;
+
+    public void OnStart(FullDisplaySurface surface)
+    {
+        // Start the decoder, scaling to surface.Width x surface.Height, BGRA.
+        // Each decoded frame: lock (_gate) { _latest = bytes; _produced++; }
+    }
+
+    public void OnStop()
+    {
+        // Stop the decoder and free its buffers. Must be safe to call at any time.
+    }
+
+    public FullDisplayFrameResult RenderFrame(byte[] buffer, in FullDisplayFrameContext frame)
+    {
+        lock (_gate)
+        {
+            if (_latest == null || _produced == _handedOut)
+                return FullDisplayFrameResult.Skip();          // nothing new — no device write
+
+            Buffer.BlockCopy(_latest, 0, buffer, 0, frame.Surface.Stride * frame.Surface.Height);
+            _handedOut = _produced;
+        }
+
+        return FullDisplayFrameResult.Frame(_handedOut);
+    }
+}
+```
+
+Wire it to a command and release it on shutdown:
+
+```csharp
+[Command("video.start", "Start Video", "Media")]
+public sealed class StartVideoCommand : IPluginCommand
+{
+    public void Execute(CommandContext context) => MyPlugin.Instance.StartVideo();
+}
+
+public override void Shutdown()
+{
+    _session?.Release();      // idempotent — safe even if it already ended
+    _session = null;
+}
+```
+
+## Notes
+
+- **Single owner.** `RequestFullDisplayRenderer` returns `null` when the display
+  is already taken (another renderer or exclusive mode) — handle it.
+- **Start it from a command, not automatically.** Same reasoning as exclusive
+  mode: entering on load would have two plugins fighting over the device.
+- **The device is fully taken over.** Buttons, touch and rotaries have no normal
+  function while you render, and **any press ends the session** (the host calls
+  `OnStop` and repaints the page) — that is the user's way out, so you don't have
+  to wire an exit yourself.
+- **A profile/workspace switch ends the takeover**, exactly like exclusive mode.
+  It does **not** auto-restart; the user re-runs your start command.
+- **Turning the device off pauses, it doesn't release.** The host stops pulling
+  frames and resumes on the next power-on, so keep your producer warm across
+  `IsActive == false` / paused stretches instead of tearing it down.
+- **Unload is covered.** The host force-releases any session your plugin still
+  holds after `Shutdown()` returns, so a renderer never keeps ticking inside an
+  unloaded plugin — but release it yourself so `OnStop` runs while your code is
+  still fully alive.
+- **Keep `OnStop` cheap and idempotent.** It can arrive from a device thread, a
+  profile switch, or shutdown. Don't try to re-enter from inside it.

--- a/docs/PluginSdk/Advanced-Screensavers-and-Side-Strips.md
+++ b/docs/PluginSdk/Advanced-Screensavers-and-Side-Strips.md
@@ -1,0 +1,61 @@
+# Plugin Screensavers and Animated Side Strips
+
+SDK 1.20.0 adds two optional animation capabilities. They are additive, so
+existing SDK 1.x plugins continue to load without a rebuild.
+
+## Plugin screensavers
+
+Implement `IScreensaverProvider` and return it from
+`LoupixPlugin.GetScreensaverProviders()`.
+
+A provider is a stateless factory with a stable `Id`, a picker `Title` and a
+`CreateRenderer()` method returning a fresh
+[`IFullDisplayRenderer`](Advanced-Full-Display-Renderer) for each idle run.
+Register it from `GetScreensaverProviders()`.
+
+The user selects `Plugin` and the provider in `Settings > Screensaver`. When the
+idle timeout expires, the host creates the renderer, calls `OnStart(surface)`,
+schedules `RenderFrame(...)`, and calls `OnStop()` when input, a context change,
+plugin unload, or shutdown ends the screensaver. Returning
+`FullDisplayFrameResult.Final(frameNumber)` ends a one-shot animation and
+restores the active page. Plugin screensavers do not need `ffmpeg`: they supply
+their own BGRA frames.
+
+Keep per-run decoding, timing and resources in the renderer and release them
+from `OnStop()`. The [Full-Display Renderer](Advanced-Full-Display-Renderer)
+page describes frame buffers, dirty keys and scheduler timing.
+
+## Side-strip providers
+
+An `ISideStripProvider` creates an `ISideStripSession` for one side of one
+rotary page. Return providers from `GetSideStripProviders()`. Users select a
+provider in a side strip's `PluginOverride` mode. `SideStripContext` identifies
+the left or right side, provides its geometry and rotary bindings, and has
+side-specific page callbacks.
+
+The host disposes the session when the user leaves its page or binding, turns
+the device off, starts a full-device takeover, unloads the plugin, or exits.
+Release timers, subscriptions and external resources in `Dispose()`. Static
+sessions keep using `StripChanged` for rate-limited redraws. FreeDraw animated
+image layers are a separate built-in path and are unchanged.
+
+## Animated side-strip sessions
+
+Implement `IAnimatedSideStripSession` on the same object as
+`ISideStripSession`. Its `TargetFps` asks the central scheduler for a rate;
+`<= 0` uses the host default and the effective rate can be lower. Use
+`frame.EffectiveFps`, `Elapsed`, and `Delta` instead of counting ticks.
+Rendering runs off the UI thread and must be fast and synchronous.
+`RenderStrip()` remains required for authoritative repaints when attaching,
+changing pages, or returning from another display owner.
+
+Return `AnimationFrameInfo.Skip()` when nothing changed,
+`AnimationFrameInfo.Frame(number)` for a continuing frame, or
+`AnimationFrameInfo.Final(number)` for the last frame. The number is a monotonic
+dirty key; reusing it avoids unnecessary device writes. For animated sessions,
+raising `StripChanged` requests the next frame immediately and resumes a
+session that returned `Final`.
+
+The host paces left and right strips independently on its shared scheduler. An
+in-flight render may overlap `Dispose()`, but no new one starts after detach, so
+guard state that disposal tears down.

--- a/docs/PluginSdk/Advanced-Settings-Page.md
+++ b/docs/PluginSdk/Advanced-Settings-Page.md
@@ -33,7 +33,7 @@ public sealed class PluginSettingDescriptor
     public required string             Label        { get; init; }
     public PluginSettingKind           Kind         { get; init; } = PluginSettingKind.Text;
     public string                      Description  { get; init; } = string.Empty;
-    public object                      DefaultValue { get; init; }
+    public object?                     DefaultValue { get; init; }
 }
 ```
 
@@ -44,8 +44,9 @@ One editable field.
 - `Label` — field label rendered next to the editor.
 - `Kind` — editor kind / stored type. See [PluginSettingKind](#pluginsettingkind).
 - `Description` — optional helper text under the field.
-- `DefaultValue` — value used when the key is absent. Match the CLR type the
-  kind stores.
+- `DefaultValue` — optional value used when the key is absent. Match the CLR
+  type the kind stores. If omitted or `null`, the host uses `string.Empty` for
+  text/password, `0` for number, or `false` for toggle.
 
 ## PluginSettingKind
 

--- a/docs/PluginSdk/Home.md
+++ b/docs/PluginSdk/Home.md
@@ -7,8 +7,8 @@ value types the host and the plugin share. A plugin is a single .NET class
 library that references this SDK, ships as a folder under the host's plugin
 directory, and is loaded dynamically at startup.
 
-- **Current SDK version:** 1.6.0
-- **Target framework:** `net10.0`
+- **Current SDK version:** 1.20.0
+- **Target frameworks:** `net9.0` and `net10.0`
 - **Package:** `LoupixDeck.PluginSdk` (NuGet)
 - **License:** MIT
 
@@ -23,6 +23,8 @@ directory, and is loaded dynamically at startup.
   - [Dynamic Menus](Advanced-Menus) — `IMenuContributor`, `MenuNode`
   - [Folder Navigation](Advanced-Folders) — `IFolderProvider`, `FolderEntry`, rotary overrides
   - [Exclusive Mode](Advanced-Exclusive-Mode) — `IExclusiveModeProvider`, `ExclusiveRenderMode`, HUD/screensaver takeovers
+  - [Full-Display Renderer](Advanced-Full-Display-Renderer) — raw BGRA video and visualizer frames
+  - [Plugin Screensavers and Animated Side Strips](Advanced-Screensavers-and-Side-Strips) — host-owned idle animations and per-side strip sessions
   - [Settings Page](Advanced-Settings-Page) — `IPluginSettingsPage`, schema, actions
 - Operations
   - [Packaging & Distribution](Packaging-and-Distribution)

--- a/docs/PluginSdk/Packaging-and-Distribution.md
+++ b/docs/PluginSdk/Packaging-and-Distribution.md
@@ -27,6 +27,11 @@ The SDK's `AssemblyVersion` is intentionally pinned at `1.0.0.0` across the
 entire 1.x package range so the plugin load context resolves one shared SDK
 assembly regardless of which 1.x package the plugin was built against.
 
+SDK 1.20.0 targets both `net9.0` and `net10.0`. Existing 1.x plugins built for
+.NET 9 continue to load in LoupixDeck v1.22.0 without a rebuild; new plugins can
+target .NET 10. The new screensaver, animated-side-strip and provider-owned
+exclusive-rendering contracts are optional and additive.
+
 ## Build output
 
 ```powershell

--- a/docs/PluginSdk/_Sidebar.md
+++ b/docs/PluginSdk/_Sidebar.md
@@ -13,6 +13,8 @@
 - [Dynamic menus](Advanced-Menus)
 - [Folder navigation](Advanced-Folders)
 - [Exclusive mode](Advanced-Exclusive-Mode)
+- [Full-display renderer](Advanced-Full-Display-Renderer)
+- [Screensavers & animated side strips](Advanced-Screensavers-and-Side-Strips)
 - [Settings page](Advanced-Settings-Page)
 
 **Operations**

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -69,7 +69,7 @@ For most users, use the installer:
 5. Choose whether LoupixDeck should start with Windows by enabling `Start on system startup`.
 6. Choose whether to launch LoupixDeck when setup finishes.
 
-The installer is self-contained, so you do not need to install the .NET runtime separately.
+The installer is self-contained, so you do not need to install the .NET runtime separately. LoupixDeck v1.22.0 and later run on .NET 10 internally; only people building the app from source need the .NET 10 SDK.
 
 If you prefer the portable build:
 
@@ -81,7 +81,7 @@ If you prefer the portable build:
 
 If LoupixDeck is already installed, the Windows setup detects the existing installation and shows the installed and available versions. You can update in place while preserving your settings, or repair a damaged installation.
 
-The updater can install in place even when the installation folder was held open by a shell command. Shell commands now run from your home directory, so programs started by them should not lock the LoupixDeck installation folder. If an update still cannot proceed, the error identifies the program that must be closed.
+The updater can install in place even when the installation folder was held open by a shell command. Shell commands now run from your home directory, so programs started by them should not lock the LoupixDeck installation folder. If an update still cannot proceed, the error identifies the program that must be closed. The installer and app use matching SkiaSharp builds; if the app cannot start, Windows now shows the startup error instead of closing silently.
 
 The installer can register LoupixDeck to start with Windows using the `Start on system startup` checkbox. In v1.12.1 and later, you can also change this after installation from `Settings > General > Start with Windows` inside LoupixDeck.
 
@@ -100,6 +100,10 @@ The installer installs the app, creates udev rules, and adds a desktop entry. Af
 ```bash
 loupixdeck
 ```
+
+### Runtime and performance
+
+In v1.22.0 and later, display frames reuse pooled buffers, WebSocket payloads are masked in place, and incoming serial data is parsed through a fixed buffer. Command parsing, lookup tables, and native calls also use lower-allocation paths. These changes are automatic; there is no performance setting to enable, and existing layouts and plugins continue to work.
 
 ## First Launch
 
@@ -216,7 +220,7 @@ Changes are saved when you close the editor.
 
 The touch-button, rotary, and physical-button editors can be resized. Drag a window edge or corner if you need more room for the preview, command sequence, or settings. Each editor has a minimum size so its controls remain usable.
 
-The command picker is wider in these editors. In the Touch Button editor, the behavior area has its own scroll bar, so a long command sequence scrolls inside that panel without pushing the main preview out of view. The Rotary and physical-button editors use the same clean picker layout without the old gray outer frame.
+The command picker is wider in these editors. In the Touch Button editor, the behavior area has its own scroll bar, so a long command sequence scrolls inside that panel without pushing the main preview out of view. The color swatch remains visible beside its editor, even in tight layouts. Command rows and section headers keep a gutter beside the scroll bar, while the selected-row highlight still spans the full row. The Rotary and physical-button editors use the same clean picker layout without the old gray outer frame.
 
 ### Editing and Rearranging Buttons
 
@@ -338,7 +342,13 @@ Some plugins offer command groups that configure a whole rotary in one step. In 
 - Dragging the group onto the strips does the same. Dropping it anywhere applies the whole mapping, while a plain command drops into a single slot.
 - Slots that the group does not define are left untouched, and every command can still be reassigned individually afterwards.
 
-For devices with side strips, each knob can also have a strip label. On the Razer Stream Controller, side strips can show segmented knob labels or be edited as free-draw strip canvases depending on mode.
+For devices with side strips, each knob can also have a strip label. On the Razer Stream Controller, open a side strip and choose its mode for the current rotary page:
+
+- `Segmented` shows the adjacent knobs as separate labelled sections.
+- `FreeDraw` uses the normal layer canvas for static or animated image content.
+- `PluginOverride` lets you choose an installed plugin provider to draw the whole strip.
+
+A plugin override may be static or animated. Animated providers are paced by LoupixDeck's display scheduler per side, so the left and right strips update steadily without changing how FreeDraw animations work. If a selected provider is unavailable, choose an installed provider again or switch the strip back to `Segmented` or `FreeDraw`.
 
 Devices with separate side displays also offer left and right variants of the rotary page commands. Use the normal `Next Rotary Page`, `Previous Rotary Page`, or `Go to Rotary Page` commands when you want both rotary columns to move together. Use the left/right variants when you want to page only one side.
 
@@ -545,6 +555,14 @@ From this page you can:
 - Select a plugin and edit its settings if it provides a settings UI.
 - Enable or disable plugins live where supported.
 
+Bundled plugins are read-only, but you can install a zip with the same plugin id to update one. LoupixDeck compares the manifest versions found in the application and user plugin folders: the higher version loads, and a tie favours the user copy. This has three useful effects:
+
+- A same-version or newer user copy can override a built-in plugin without changing the application folder.
+- If an app update later includes a newer bundled copy, that version takes over automatically.
+- Removing the user override restores the bundled copy and keeps the plugin enabled. If its files are in use, the restore completes after the next restart.
+
+An older zip cannot replace a newer bundled copy; the Plugins page reports why it would not be loaded.
+
 The current binary installation includes these plugin manifests:
 
 | Plugin | Platform |
@@ -712,12 +730,15 @@ On Windows, `Start with Windows` controls whether LoupixDeck launches at login. 
 ### Screensaver
 
 - Enable animated screensaver.
-- Select video/GIF source.
-- Set idle timeout, FPS limit, and looping.
+- Choose `Video` or `Plugin` as the source.
+- Select a video/GIF or an installed plugin provider.
+- Set idle timeout and FPS limit; looping applies to video sources.
+- Install `ffmpeg` only when using a video source.
 
 ### Plugins
 
 - Install, remove, open folder, and configure plugins.
+- User copies can update bundled plugins; removing an override restores the bundled version.
 
 ### Macro Driver
 
@@ -818,7 +839,7 @@ Sensor plugins changed from plain text output to tile rendering. If an old Argus
 
 ### Collecting crash logs
 
-If LoupixDeck closes unexpectedly, start it with a diagnostics flag to record what happened:
+If LoupixDeck cannot start, current Windows releases first show the startup error in a message box instead of closing silently. If LoupixDeck closes unexpectedly after startup, start it with a diagnostics flag to record what happened:
 
 ```bash
 ./LoupixDeck --crashlog


### PR DESCRIPTION
Updates the documentation for LoupixDeck v1.22.0.

User documentation:
- Documents Video vs Plugin screensaver sources, including that only video needs ffmpeg.
- Documents PluginOverride side-strip mode, per-side scheduler pacing, and unchanged FreeDraw behavior.
- Explains bundled-plugin overrides: version selection, app-update precedence, and revert-on-remove behavior.
- Adds .NET 10, allocation-reduction, startup-error, Touch editor, and command-picker polish notes.

Plugin SDK documentation:
- Updates the SDK overview to 1.20.0 with net9.0/net10.0 compatibility.
- Adds full-display renderer and plugin screensaver/animated-side-strip guidance.
- Documents GetScreensaverProviders, side-strip providers, optional PluginSettingDescriptor.DefaultValue, and ExclusiveRenderMode.None.

Validation:
- Branch is based on v1.22.0 commit ac9025af6773e48769a8e19a1b816ef67520135a.
- git diff --check passed after staging.
- Verified the new Markdown documentation targets and required headings locally.
- Pushed fork branch verified with git ls-remote at e83343d706c426b340151bbf36e681732c953709.