### PR TITLE
fix(picker): keep an empty plugin group instead of dropping it

### DIFF
--- a/LoupixDeck/Services/Commands/MenuTreeBuilder.cs
+++ b/LoupixDeck/Services/Commands/MenuTreeBuilder.cs
@@ -102,8 +102,11 @@ public class MenuTreeBuilder : IMenuTreeBuilder
             foreach (var group in groups.Where(g => g != null))
                 MergeGroup(target, group);
 
-            // Clear the loading state; drop any group that stayed an empty stub
-            // (a plugin with only hidden commands that failed to contribute).
+            // Clear the loading state. A group that stayed an empty stub keeps its
+            // card and gets a non-actionable info row instead of being removed: a
+            // plugin whose commands are all hidden (it contributes only dynamic
+            // submenus) would otherwise vanish from the picker entirely, leaving no
+            // hint that it is loaded but currently has nothing to offer.
             foreach (var groupName in source.GroupNames)
             {
                 var group = target.FirstOrDefault(g => g.Name == groupName);
@@ -112,10 +115,21 @@ public class MenuTreeBuilder : IMenuTreeBuilder
 
                 group.IsLoading = false;
                 if (group.Children.Count == 0 && CoreGroupIndex(group) == int.MaxValue)
-                    target.Remove(group);
+                    group.Children.Add(EmptyGroupNotice(source.PluginName));
             }
         });
     }
+
+    /// <summary>
+    /// The placeholder leaf shown inside a plugin group that contributed nothing.
+    /// It carries no command and no children, so the picker classifies it as a
+    /// non-actionable info row: visible, but neither selectable nor insertable.
+    /// </summary>
+    private static MenuEntry EmptyGroupNotice(string pluginName) =>
+        new("Nothing to show", string.Empty)
+        {
+            Description = $"'{pluginName}' is loaded but currently offers no commands."
+        };
 
     /// <summary>
     /// Adds <paramref name="group"/> to <paramref name="target"/>: if a group

--- a/LoupixDeck/ViewModels/CommandPicker/CommandPickerItems.cs
+++ b/LoupixDeck/ViewModels/CommandPicker/CommandPickerItems.cs
@@ -89,6 +89,11 @@ public partial class CommandRowViewModel : ViewModelBase
     /// <summary>Resolved row glyph: the command's own icon, else the category icon.</summary>
     public string Icon { get; }
 
+    /// <summary>False for a non-actionable info row (a leaf with neither a command
+    /// nor children, e.g. "No Key Lights found"). Such a row is shown greyed out and
+    /// can be neither selected nor inserted.</summary>
+    public bool IsSelectable => Entry.IsCommand();
+
     [ObservableProperty]
     public partial bool IsSelected { get; set; }
 

--- a/LoupixDeck/ViewModels/CommandPicker/CommandPickerViewModel.cs
+++ b/LoupixDeck/ViewModels/CommandPicker/CommandPickerViewModel.cs
@@ -123,6 +123,11 @@ public partial class CommandPickerViewModel : ViewModelBase
 
     public void SelectCommand(CommandRowViewModel command)
     {
+        // Info rows carry no command — they stay unselectable so the footer's
+        // "+ Add" can never insert an empty assignment.
+        if (command is { IsSelectable: false })
+            return;
+
         if (SelectedCommand != null)
             SelectedCommand.IsSelected = false;
 

--- a/LoupixDeck/Views/CommandPickerView.axaml
+++ b/LoupixDeck/Views/CommandPickerView.axaml
@@ -20,7 +20,8 @@
         <DataTemplate DataType="vm:CommandRowViewModel">
             <Border Classes="picker-row-face"
                     Classes.selected="{Binding IsSelected}"
-                    Focusable="True"
+                    Classes.info="{Binding !IsSelectable}"
+                    Focusable="{Binding IsSelectable}"
                     PointerPressed="Row_PointerPressed"
                     DoubleTapped="Row_DoubleTapped"
                     KeyDown="Row_KeyDown">

--- a/LoupixDeck/Views/CommandPickerView.axaml.cs
+++ b/LoupixDeck/Views/CommandPickerView.axaml.cs
@@ -62,7 +62,7 @@ public partial class CommandPickerView : UserControl
 
     private void Row_PointerPressed(object sender, PointerPressedEventArgs e)
     {
-        if (sender is not Control { DataContext: CommandRowViewModel row })
+        if (sender is not Control { DataContext: CommandRowViewModel row } || !row.IsSelectable)
             return;
         if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             return;
@@ -76,7 +76,7 @@ public partial class CommandPickerView : UserControl
 
     private void Row_DoubleTapped(object sender, TappedEventArgs e)
     {
-        if (sender is not Control { DataContext: CommandRowViewModel row })
+        if (sender is not Control { DataContext: CommandRowViewModel row } || !row.IsSelectable)
             return;
 
         CommandActivated?.Invoke(this, row.Entry);
@@ -98,7 +98,7 @@ public partial class CommandPickerView : UserControl
 
     private void Row_KeyDown(object sender, KeyEventArgs e)
     {
-        if (sender is not Control { DataContext: CommandRowViewModel row })
+        if (sender is not Control { DataContext: CommandRowViewModel row } || !row.IsSelectable)
             return;
 
         switch (e.Key)

--- a/LoupixDeck/Views/Styles/CommandPickerStyles.axaml
+++ b/LoupixDeck/Views/Styles/CommandPickerStyles.axaml
@@ -247,6 +247,19 @@
         <Setter Property="Background" Value="{DynamicResource PickerAccentSubtle}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PickerAccentBrush}" />
     </Style>
+    <!-- Info row: a non-actionable notice inside an otherwise empty group. No hover
+         affordance and a muted title, so it never reads as an insertable command. -->
+    <Style Selector="Border.picker-row-face.info">
+        <Setter Property="Cursor" Value="Arrow" />
+    </Style>
+    <Style Selector="Border.picker-row-face.info:pointerover">
+        <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="Border.picker-row-face.info TextBlock.picker-row-title">
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="FontStyle" Value="Italic" />
+        <Setter Property="Foreground" Value="{DynamicResource AppTextSecondary}" />
+    </Style>
 
     <!-- Explicit line heights keep the two-line row at a fixed 50 px regardless of the
          font's own metrics. -->


### PR DESCRIPTION
A plugin whose commands are all HiddenFromMenu contributes its group only through IMenuContributor. When the dynamic submenus came back empty the builder removed the group outright, so the plugin vanished from the picker with no hint that it was loaded — the Elgato Key Lights group disappeared whenever no light was known.

The group now keeps its card and receives a non-actionable info row. Such a row (a leaf with neither a command nor children) is greyed out, unfocusable, and gated out of selection and insertion, so "+ Add", double-click and Enter can never assign an empty command from it.

Claude-Session: https://claude.ai/code/session_01TdfkZYrQLszH89d1rNjgaQ