### PR TITLE
Let the app start when the serial port is busy

### DIFF
--- a/LoupixDeck/LoupedeckDevice/Device/LoupedeckDevice.cs
+++ b/LoupixDeck/LoupedeckDevice/Device/LoupedeckDevice.cs
@@ -727,6 +727,18 @@ public class LoupedeckDevice
         bool returnDataToPool,
         bool hasReservedWsPrefix)
     {
+        // When the device isn't connected — e.g. another process is momentarily holding the serial
+        // port at startup — skip physical I/O instead of enqueuing a command that can never be acked
+        // and would time out. Making the write a no-op lets Initialize finish building the in-memory
+        // model so the window can open; a later reconnect redraws the device. Without this the
+        // startup timeout aborted device bring-up and shut the whole app down.
+        if (_connection is not { IsReady: true })
+        {
+            if (returnDataToPool)
+                ArrayPool<byte>.Shared.Return(data);
+            return [];
+        }
+
         TaskCompletionSource<byte[]> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         CancellationTokenSource timeoutCts = expectResponse
             ? RentTimeoutCts(timeout!.Value)


### PR DESCRIPTION
EnqueueAsync now skips physical I/O when the device isn't connected (_connection not IsReady) instead of enqueuing a command that never gets acked and eventually times out. That timeout previously aborted device bring-up during Initialize, so the whole app shut down and wouldn't open from its icon while another process momentarily held the serial port at startup. Turning the write into a no-op lets the in-memory model finish building and the window open; a later reconnect redraws the device.