### PR TITLE
Recover from a busy serial port: open backoff + hot-plug reconnect

### DIFF
--- a/LoupixDeck/Controllers/IDeviceController.cs
+++ b/LoupixDeck/Controllers/IDeviceController.cs
@@ -19,6 +19,20 @@ public interface IDeviceController
     /// </summary>
     bool IsDeviceOff { get; }
 
+    /// <summary>
+    /// True while the device's serial link is open and usable. A device can be present on the
+    /// USB bus yet not connected — e.g. another program held its port at startup — in which case
+    /// the hot-plug reconciler uses this to know a reconnect is needed.
+    /// </summary>
+    bool IsDeviceConnected { get; }
+
+    /// <summary>
+    /// Requests a single background reconnect for a device that is present but whose serial link
+    /// is down (its port was momentarily busy). Non-blocking and self-throttling: a call is
+    /// dropped while another reconnect is already in flight. Safe to call repeatedly.
+    /// </summary>
+    void RequestReconnect();
+
     Task Initialize(string port = null, int baudrate = 0);
     void SaveConfig();
 

--- a/LoupixDeck/Controllers/LoupedeckLiveSController.cs
+++ b/LoupixDeck/Controllers/LoupedeckLiveSController.cs
@@ -72,6 +72,27 @@ public partial class LoupedeckLiveSController(
     private volatile bool _isDeviceOff;
     public bool IsDeviceOff => _isDeviceOff;
 
+    /// <inheritdoc />
+    public bool IsDeviceConnected => deviceService.Device?.IsConnected == true;
+
+    // 0 = idle, 1 = a reconnect is running. Guards RequestReconnect so overlapping hot-plug
+    // ticks (and the device's own auto-reconnect loop) can't pile up port tear-downs.
+    private int _reconnectInFlight;
+
+    /// <inheritdoc />
+    public void RequestReconnect()
+    {
+        if (System.Threading.Interlocked.CompareExchange(ref _reconnectInFlight, 1, 0) != 0)
+            return;
+
+        _ = Task.Run(() =>
+        {
+            try { deviceService.ReconnectDevice(); }
+            catch (Exception ex) { Console.WriteLine($"[HotPlug] reconnect failed: {ex.Message}"); }
+            finally { System.Threading.Interlocked.Exchange(ref _reconnectInFlight, 0); }
+        });
+    }
+
     /// <summary>
     /// True while the off state was entered by the host suspending, not by the user. The
     /// hardware power-cycles across a suspend, so the next connect is proof the device is

--- a/LoupixDeck/LoupedeckDevice/Serial/SerialConnection.cs
+++ b/LoupixDeck/LoupedeckDevice/Serial/SerialConnection.cs
@@ -120,7 +120,7 @@ public class SerialConnection : ISerialConnection
                 Encoding = Encoding.UTF8
             };
 
-            _serialPort.Open();
+            OpenWithBackoff();
 
             // Perform the handshake to get the device into Websocket mode on the Serial Port
             if (!PerformHandshake())
@@ -166,6 +166,42 @@ public class SerialConnection : ISerialConnection
 
             // Rethrow the exception if needed.
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Opens the port, retrying with exponential backoff when it is momentarily unavailable.
+    ///
+    /// At boot another program (the vendor's own Loupedeck app / Logi service) frequently holds
+    /// the port for a fraction of a second, so the first <see cref="SerialPort.Open"/> loses the
+    /// race and throws <see cref="UnauthorizedAccessException"/> (or <see cref="IOException"/>).
+    /// Instead of giving up, wait 200/400/800/1600 ms and try again — the port is almost always
+    /// free within a second or two. Costs nothing on success and removes the startup race without
+    /// touching any external process.
+    ///
+    /// This runs on <c>DeviceService</c>'s dedicated device thread (see <c>StartDevice</c>), never
+    /// the UI thread, so the waits do not block the UI. A non-transient failure (final attempt, or
+    /// any other exception) propagates to <see cref="Connect"/>'s handler as before.
+    /// </summary>
+    private void OpenWithBackoff()
+    {
+        const int maxAttempts = 5;
+        var backoffMs = 200;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                _serialPort!.Open();
+                return;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException && attempt < maxAttempts)
+            {
+                Console.WriteLine(
+                    $"[Serial] '{_portName}' is in use (attempt {attempt}/{maxAttempts}); retrying in {backoffMs} ms.");
+                Thread.Sleep(backoffMs);
+                backoffMs *= 2;
+            }
         }
     }
 

--- a/LoupixDeck/Services/HotPlug/HotPlugManager.cs
+++ b/LoupixDeck/Services/HotPlug/HotPlugManager.cs
@@ -14,6 +14,12 @@ public sealed class HotPlugManager : IHotPlugManager
     // watcher won't keep firing on its own).
     private const int ReArmMs = 600;
 
+    // A present-but-disconnected device (its port is held by another program) produces no USB
+    // event when the port finally frees, so keep re-running reconcile on this slower cadence to
+    // retry the reconnect until it succeeds. Slower than ReArmMs because a device scan is not
+    // free and this can run for as long as the other program keeps the port.
+    private const int ReviveMs = 3000;
+
     // A device must be missing from this many consecutive scans before we detach
     // it. Guards against a single failed/raced USB scan tearing a live device down
     // (and smooths a quick unplug→replug, which the device's own auto-reconnect
@@ -131,10 +137,29 @@ public sealed class HotPlugManager : IHotPlugManager
                 Raise(DeviceAttached, device);
             }
 
-            // Self-re-arm while a removal is still being confirmed or a detach is
-            // pending host removal, so we don't depend on another external event.
+            // ── Revive: a present device whose serial link is down. ──
+            // The device is on the bus but its port was taken (e.g. the vendor's own Loupedeck
+            // app grabbed it), so its host stays up with a dead connection. Presence alone never
+            // triggers a reconnect — the attach loop skips it (a host already exists) and freeing
+            // the port raises no USB event. Kick a reconnect from here so that the moment the port
+            // frees we take it over, without a restart and without killing anything. RequestReconnect
+            // is non-blocking and self-throttling (it complements the device's own reconnect loop).
+            var reviving = false;
+            foreach (var host in hosts)
+            {
+                if (!scanKeys.Contains(host.Device.ScopeKey)) continue; // gone — handled by detach
+                if (host.Controller.IsDeviceConnected) continue;        // already live
+                reviving = true;
+                host.Controller.RequestReconnect();
+            }
+
+            // Self-re-arm: while a removal is still being confirmed or a detach is pending host
+            // removal (ReArmMs), or while a present device is still being revived (the slower
+            // ReviveMs), so recovery never depends on another external event.
             if (_missCounts.Count > 0 || _detaching.Count > 0)
                 ScheduleReconcile(ReArmMs);
+            else if (reviving)
+                ScheduleReconcile(ReviveMs);
         }
         finally
         {


### PR DESCRIPTION
Follow-up to your review of #219 / #220 — this drops the process-killing from #220 and takes the approach you laid out. It covers points 1 and 2 (the serial-layer fixes); the on-screen status message and the one-time autostart notice (points 3–4) will come as a separate UI PR.

## 1. Retry the serial open with backoff
The busy-port case at startup is transient — another program holds the port for a fraction of a second. `SerialConnection.Connect()` now wraps `Open()` in `OpenWithBackoff()`: up to 5 attempts spaced 200/400/800/1600 ms. Removes the boot race without touching any external process; costs nothing on success. It runs on DeviceService's dedicated device thread (not the UI thread), so the waits don't block the UI — happy to switch it to an async `ConnectAsync` if you'd prefer.

## 2. Reconnect a present-but-disconnected device from the hot-plug reconciler
The real gap: `HotPlugManager.Reconcile()` only compared USB presence against running hosts, so a device that's present but whose link is down (port taken) kept running with a dead connection and never reconnected — freeing the port raises no USB event. Added `IDeviceController.IsDeviceConnected` + `RequestReconnect()`, and a revive pass in `Reconcile` that reconnects such a host and re-arms the timer until it succeeds. So closing the vendor app hands the port over automatically, no restart, no kill. `RequestReconnect` is non-blocking and self-throttling; it complements the device's own auto-reconnect loop.

Supersedes #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)